### PR TITLE
[Alerting] Consolidate unified-alerting a11y + theme + i18n (supersedes #2827, #2825, #2839)

### DIFF
--- a/common/services/alerting/__tests__/filter.test.ts
+++ b/common/services/alerting/__tests__/filter.test.ts
@@ -168,8 +168,18 @@ describe('filter', () => {
     it('matches a single labelKey:value term against the label, not as a substring', () => {
       expect(alertMatchesSearch(alert, 'slo_id:abc-123')).toBe(true);
       expect(alertMatchesSearch(alert, 'slo_id:abc')).toBe(true); // includes()
-      expect(alertMatchesSearch(alert, 'slo_id:zzz')).toBe(false);
-      expect(alertMatchesSearch(alert, 'other:abc-123')).toBe(false); // wrong key
+      expect(alertMatchesSearch(alert, 'slo_id:zzz')).toBe(false); // real key, no value match
+    });
+
+    it('falls back to substring match when the colon-term key is not a label', () => {
+      // `other` is not a label on the alert, so the term is treated as free text.
+      const withColonInMessage = {
+        name: 'HighCpu',
+        message: 'saw error:timeout in logs',
+        labels: { slo_id: 'abc-123' },
+      };
+      expect(alertMatchesSearch(withColonInMessage, 'error:timeout')).toBe(true); // substring hit
+      expect(alertMatchesSearch(alert, 'other:abc-123')).toBe(false); // no label, no substring
     });
 
     it('keeps whole-string substring behavior for free-text (with a space)', () => {

--- a/common/services/alerting/__tests__/filter.test.ts
+++ b/common/services/alerting/__tests__/filter.test.ts
@@ -3,7 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { emptyFilters, filterAlerts, matchesFilters, matchesSearch } from '../filter';
+import {
+  alertMatchesSearch,
+  emptyFilters,
+  filterAlerts,
+  matchesFilters,
+  matchesSearch,
+  sortRules,
+} from '../filter';
 
 describe('filter', () => {
   describe('emptyFilters', () => {
@@ -134,6 +141,41 @@ describe('filter', () => {
       expect(filterAlerts(alerts, { search: 'storage' }).map((a) => a.name)).toEqual(['LowDisk']);
       // alert without message still searches name/labels
       expect(filterAlerts(alerts, { search: 'oom' }).map((a) => a.name)).toEqual(['OomKill']);
+    });
+
+    it('scopes to a single SLO via a `slo_id:<id>` label deep-link (SLO detail "View alerts" pivot)', () => {
+      const sloAlerts = [
+        { name: 'BurnA', severity: 'critical', state: 'firing', labels: { slo_id: 'abc-123' } },
+        { name: 'BurnB', severity: 'warning', state: 'firing', labels: { slo_id: 'def-456' } },
+      ];
+      // The value alone won't appear as a literal `slo_id:abc-123` substring in
+      // any field — the label-aware branch is what makes this match.
+      expect(filterAlerts(sloAlerts, { search: 'slo_id:abc-123' }).map((a) => a.name)).toEqual([
+        'BurnA',
+      ]);
+      expect(filterAlerts(sloAlerts, { search: 'slo_id:none' })).toHaveLength(0);
+    });
+  });
+
+  describe('alertMatchesSearch', () => {
+    const alert = { name: 'HighCpu', message: 'CPU over threshold', labels: { slo_id: 'abc-123' } };
+
+    it('matches an empty query', () => {
+      expect(alertMatchesSearch(alert, '')).toBe(true);
+      expect(alertMatchesSearch(alert, '   ')).toBe(true);
+    });
+
+    it('matches a single labelKey:value term against the label, not as a substring', () => {
+      expect(alertMatchesSearch(alert, 'slo_id:abc-123')).toBe(true);
+      expect(alertMatchesSearch(alert, 'slo_id:abc')).toBe(true); // includes()
+      expect(alertMatchesSearch(alert, 'slo_id:zzz')).toBe(false);
+      expect(alertMatchesSearch(alert, 'other:abc-123')).toBe(false); // wrong key
+    });
+
+    it('keeps whole-string substring behavior for free-text (with a space)', () => {
+      expect(alertMatchesSearch(alert, 'cpu over')).toBe(true); // message substring
+      expect(alertMatchesSearch(alert, 'highcpu')).toBe(true); // name substring
+      expect(alertMatchesSearch(alert, 'no match')).toBe(false);
     });
   });
 });

--- a/common/services/alerting/filter.ts
+++ b/common/services/alerting/filter.ts
@@ -63,9 +63,13 @@ export function matchesSearch(
  * against the label rather than as a literal substring — the SLO detail
  * "View alerts" pivot deep-links with exactly this shape, and a plain substring
  * search would never match because the label value doesn't contain the `key:`
- * prefix. Any other query keeps the original whole-string substring behavior
- * over name / message / label values, so multi-word free-text search is
- * unchanged.
+ * prefix. The label interpretation only applies when the parsed key is actually
+ * a label on the alert; otherwise the term is treated as free text and falls
+ * through to the substring path below. This keeps free-text queries that happen
+ * to contain a colon (e.g. a pasted `error:timeout` message fragment or URL)
+ * from silently matching nothing. Any other query keeps the original
+ * whole-string substring behavior over name / message / label values, so
+ * multi-word free-text search is unchanged.
  */
 export function alertMatchesSearch(
   alert: { name: string; message?: string; labels: Record<string, string> },
@@ -76,9 +80,13 @@ export function alertMatchesSearch(
   const colonIdx = raw.indexOf(':');
   if (colonIdx > 0 && !/\s/.test(raw)) {
     const key = raw.slice(0, colonIdx).toLowerCase();
-    const val = raw.slice(colonIdx + 1).toLowerCase();
     const labelVal = alert.labels[key];
-    return Boolean(labelVal && labelVal.toLowerCase().includes(val));
+    // Only interpret as a label search when the key names a real label on this
+    // alert; otherwise fall through to substring matching on the raw term.
+    if (labelVal !== undefined) {
+      const val = raw.slice(colonIdx + 1).toLowerCase();
+      return labelVal.toLowerCase().includes(val);
+    }
   }
   const q = raw.toLowerCase();
   return (

--- a/common/services/alerting/filter.ts
+++ b/common/services/alerting/filter.ts
@@ -56,6 +56,38 @@ export function matchesSearch(
   });
 }
 
+/**
+ * Search predicate for alert summaries (name + message + labels).
+ *
+ * A single `labelKey:value` term (no whitespace, e.g. `slo_id:<id>`) is matched
+ * against the label rather than as a literal substring — the SLO detail
+ * "View alerts" pivot deep-links with exactly this shape, and a plain substring
+ * search would never match because the label value doesn't contain the `key:`
+ * prefix. Any other query keeps the original whole-string substring behavior
+ * over name / message / label values, so multi-word free-text search is
+ * unchanged.
+ */
+export function alertMatchesSearch(
+  alert: { name: string; message?: string; labels: Record<string, string> },
+  query: string
+): boolean {
+  const raw = query.trim();
+  if (!raw) return true;
+  const colonIdx = raw.indexOf(':');
+  if (colonIdx > 0 && !/\s/.test(raw)) {
+    const key = raw.slice(0, colonIdx).toLowerCase();
+    const val = raw.slice(colonIdx + 1).toLowerCase();
+    const labelVal = alert.labels[key];
+    return Boolean(labelVal && labelVal.toLowerCase().includes(val));
+  }
+  const q = raw.toLowerCase();
+  return (
+    alert.name.toLowerCase().includes(q) ||
+    (alert.message || '').toLowerCase().includes(q) ||
+    Object.values(alert.labels).some((v) => v.toLowerCase().includes(q))
+  );
+}
+
 export function matchesFilters(
   rule: {
     status: string;
@@ -89,6 +121,28 @@ export function matchesFilters(
   return true;
 }
 
+export function sortRules<T>(
+  rules: T[],
+  field: string,
+  direction: 'asc' | 'desc',
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accessor return type varies by field
+  accessor?: (item: T, field: string) => any
+): T[] {
+  const sorted = [...rules];
+  sorted.sort((a, b) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic field access for generic sort
+    let aVal = accessor ? accessor(a, field) : ((a as Record<string, any>)[field] ?? '');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- dynamic field access for generic sort
+    let bVal = accessor ? accessor(b, field) : ((b as Record<string, any>)[field] ?? '');
+    if (typeof aVal === 'string') aVal = aVal.toLowerCase();
+    if (typeof bVal === 'string') bVal = bVal.toLowerCase();
+    if (aVal < bVal) return direction === 'asc' ? -1 : 1;
+    if (aVal > bVal) return direction === 'asc' ? 1 : -1;
+    return 0;
+  });
+  return sorted;
+}
+
 export function filterAlerts<
   T extends {
     alertKind?: string;
@@ -120,15 +174,8 @@ export function filterAlerts<
         if (values.length > 0 && (!a.labels[key] || !values.includes(a.labels[key]))) return false;
       }
     }
-    if (filters.search) {
-      const q = filters.search.toLowerCase();
-      if (
-        !a.name.toLowerCase().includes(q) &&
-        !(a.message || '').toLowerCase().includes(q) &&
-        !Object.values(a.labels).some((v) => v.toLowerCase().includes(q))
-      ) {
-        return false;
-      }
+    if (filters.search && !alertMatchesSearch(a, filters.search)) {
+      return false;
     }
     return true;
   });

--- a/public/components/alerting/__tests__/alert_detail_flyout.test.tsx
+++ b/public/components/alerting/__tests__/alert_detail_flyout.test.tsx
@@ -439,6 +439,7 @@ describe('AlertDetailFlyout', () => {
       // The action is labelled "Open SLO" whenever `slo_id` is present, and the
       // source row names the SLO instead of repeating the action label.
       expect(getByText('Source SLO')).toBeInTheDocument();
+      expect(getByTestId('alertDetailOpenSource')).toHaveTextContent('Open SLO');
       expect(getByTestId('alertDetailSourceRuleLink')).toHaveTextContent('API availability');
       fireEvent.click(getByTestId('alertDetailOpenSource'));
       expect(onClose).toHaveBeenCalledTimes(1);
@@ -463,6 +464,7 @@ describe('AlertDetailFlyout', () => {
         />
       );
       expect(getByText('Source rule')).toBeInTheDocument();
+      expect(getByTestId('alertDetailOpenSource')).toHaveTextContent('Open rule');
       expect(getByTestId('alertDetailSourceRuleLink')).toHaveTextContent('High latency');
       fireEvent.click(getByTestId('alertDetailOpenSource'));
       // Rule deep-links stay inside the alerting app (hash-only), so

--- a/public/components/alerting/__tests__/alert_detail_flyout.test.tsx
+++ b/public/components/alerting/__tests__/alert_detail_flyout.test.tsx
@@ -492,6 +492,56 @@ describe('AlertDetailFlyout', () => {
     });
   });
 
+  describe('detail-list formatting parity with the alerts table', () => {
+    it('title-cases the State and Severity values instead of showing raw enums', () => {
+      const { getAllByText, queryByText } = render(
+        <AlertDetailFlyout
+          alert={baseAlert}
+          datasources={datasources}
+          onClose={jest.fn()}
+          onAcknowledge={jest.fn()}
+        />
+      );
+      // The alerts table renders "Active"/"Critical"; the flyout used to show
+      // the raw backend enums, so the same alert read two different ways on
+      // the same screen. Each value appears twice — once as a header chip, once
+      // in the detail list — and no lowercase rendering may survive anywhere.
+      expect(getAllByText('Active')).toHaveLength(2);
+      expect(getAllByText('Critical')).toHaveLength(2);
+      expect(queryByText('active')).toBeNull();
+      expect(queryByText('critical')).toBeNull();
+    });
+
+    it('names the timezone on the Started and Last Updated timestamps', () => {
+      const { getAllByText } = render(
+        <AlertDetailFlyout
+          alert={{ ...baseAlert, startTime: '2026-06-04T20:00:00.000Z' }}
+          datasources={datasources}
+          onClose={jest.fn()}
+          onAcknowledge={jest.fn()}
+        />
+      );
+      // `toLocaleString()` never says which zone it rendered in. Assert the
+      // zone-labelled shape rather than a fixed string, so the test doesn't
+      // depend on the machine's timezone. Both Started and Last Updated match.
+      expect(getAllByText(/^\w{3} \d{1,2}, 20\d{2} @ \d{2}:\d{2}:\d{2} \S+$/)).toHaveLength(2);
+    });
+
+    it('renders the shared em-dash placeholder when a timestamp is missing', () => {
+      const { getAllByText } = render(
+        <AlertDetailFlyout
+          alert={{ ...baseAlert, lastUpdated: '' }}
+          datasources={datasources}
+          onClose={jest.fn()}
+          onAcknowledge={jest.fn()}
+        />
+      );
+      // Not "Invalid date", and not the flyout's old "Not available" wording —
+      // the same glyph the table uses for an empty cell.
+      expect(getAllByText('—').length).toBeGreaterThan(0);
+    });
+  });
+
   describe('annotation runbook links (SRE2)', () => {
     it('renders a runbook URL annotation as a clickable external link', () => {
       const alertWithRunbook: UnifiedAlertSummary = {

--- a/public/components/alerting/__tests__/alert_detail_flyout.test.tsx
+++ b/public/components/alerting/__tests__/alert_detail_flyout.test.tsx
@@ -63,8 +63,20 @@ jest.mock('../query_services/alerting_opensearch_service', () => ({
   })),
 }));
 
+// Stub the shared core refs so the cross-app SLO deep-link can assert on
+// `navigateToApp` without a real Core start contract.
+jest.mock('../../../framework/core_refs', () => ({
+  coreRefs: {
+    application: { navigateToApp: jest.fn() },
+  },
+}));
+
 import { AlertDetailFlyout } from '../alert_detail_flyout';
+import { coreRefs } from '../../../framework/core_refs';
+import { observabilityApmSloID } from '../../../../common/constants/apm';
 import type { Datasource, UnifiedAlertSummary } from '../../../../common/types/alerting';
+
+const navigateToApp = coreRefs.application!.navigateToApp as jest.Mock;
 
 const baseAlert: UnifiedAlertSummary = {
   id: 'alert-42',
@@ -401,6 +413,77 @@ describe('AlertDetailFlyout', () => {
       );
       fireEvent.click(getByText('Raw Alert Data'));
       expect(mockGetAlertDetail).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('source deep-link (OBS1)', () => {
+    beforeEach(() => {
+      navigateToApp.mockClear();
+    });
+
+    it('pivots an SLO burn-rate alert to the SLO detail page in the SLO app', () => {
+      const onClose = jest.fn();
+      const sloAlert: UnifiedAlertSummary = {
+        ...baseAlert,
+        datasourceType: 'prometheus',
+        labels: { slo_id: 'slo/api ok', alertname: 'BurnRate' },
+      };
+      const { getByText } = render(
+        <AlertDetailFlyout
+          alert={sloAlert}
+          datasources={datasources}
+          onClose={onClose}
+          onAcknowledge={jest.fn()}
+        />
+      );
+      // The action is labelled "Open SLO" whenever `slo_id` is present.
+      fireEvent.click(getByText('Open SLO'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+      // Cross-app navigation to the SLO detail route, with the id encoded.
+      expect(navigateToApp).toHaveBeenCalledWith(observabilityApmSloID, {
+        path: `#/slos/${encodeURIComponent('slo/api ok')}`,
+      });
+    });
+
+    it('does not cross apps for a monitor rule deep-link', () => {
+      const monitorAlert: UnifiedAlertSummary = {
+        ...baseAlert,
+        datasourceType: 'opensearch',
+        labels: { monitor_id: 'mon-7' },
+      };
+      const { getByText } = render(
+        <AlertDetailFlyout
+          alert={monitorAlert}
+          datasources={datasources}
+          onClose={jest.fn()}
+          onAcknowledge={jest.fn()}
+        />
+      );
+      fireEvent.click(getByText('Open rule'));
+      // Rule deep-links stay inside the alerting app (hash-only), so
+      // navigateToApp must not fire.
+      expect(navigateToApp).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('annotation runbook links (SRE2)', () => {
+    it('renders a runbook URL annotation as a clickable external link', () => {
+      const alertWithRunbook: UnifiedAlertSummary = {
+        ...baseAlert,
+        annotations: { runbook: 'https://runbooks.example/api' },
+      };
+      const { getByText } = render(
+        <AlertDetailFlyout
+          alert={alertWithRunbook}
+          datasources={datasources}
+          onClose={jest.fn()}
+          onAcknowledge={jest.fn()}
+        />
+      );
+      const link = getByText('https://runbooks.example/api');
+      expect(link.tagName).toBe('A');
+      expect(link).toHaveAttribute('href', 'https://runbooks.example/api');
+      expect(link).toHaveAttribute('target', '_blank');
     });
   });
 

--- a/public/components/alerting/__tests__/alert_detail_flyout.test.tsx
+++ b/public/components/alerting/__tests__/alert_detail_flyout.test.tsx
@@ -426,9 +426,9 @@ describe('AlertDetailFlyout', () => {
       const sloAlert: UnifiedAlertSummary = {
         ...baseAlert,
         datasourceType: 'prometheus',
-        labels: { slo_id: 'slo/api ok', alertname: 'BurnRate' },
+        labels: { slo_id: 'slo/api ok', slo_name: 'API availability', alertname: 'BurnRate' },
       };
-      const { getByText } = render(
+      const { getByText, getByTestId } = render(
         <AlertDetailFlyout
           alert={sloAlert}
           datasources={datasources}
@@ -436,8 +436,11 @@ describe('AlertDetailFlyout', () => {
           onAcknowledge={jest.fn()}
         />
       );
-      // The action is labelled "Open SLO" whenever `slo_id` is present.
-      fireEvent.click(getByText('Open SLO'));
+      // The action is labelled "Open SLO" whenever `slo_id` is present, and the
+      // source row names the SLO instead of repeating the action label.
+      expect(getByText('Source SLO')).toBeInTheDocument();
+      expect(getByTestId('alertDetailSourceRuleLink')).toHaveTextContent('API availability');
+      fireEvent.click(getByTestId('alertDetailOpenSource'));
       expect(onClose).toHaveBeenCalledTimes(1);
       // Cross-app navigation to the SLO detail route, with the id encoded.
       expect(navigateToApp).toHaveBeenCalledWith(observabilityApmSloID, {
@@ -449,9 +452,9 @@ describe('AlertDetailFlyout', () => {
       const monitorAlert: UnifiedAlertSummary = {
         ...baseAlert,
         datasourceType: 'opensearch',
-        labels: { monitor_id: 'mon-7' },
+        labels: { monitor_id: 'mon-7', monitor_name: 'High latency' },
       };
-      const { getByText } = render(
+      const { getByText, getByTestId } = render(
         <AlertDetailFlyout
           alert={monitorAlert}
           datasources={datasources}
@@ -459,10 +462,31 @@ describe('AlertDetailFlyout', () => {
           onAcknowledge={jest.fn()}
         />
       );
-      fireEvent.click(getByText('Open rule'));
+      expect(getByText('Source rule')).toBeInTheDocument();
+      expect(getByTestId('alertDetailSourceRuleLink')).toHaveTextContent('High latency');
+      fireEvent.click(getByTestId('alertDetailOpenSource'));
       // Rule deep-links stay inside the alerting app (hash-only), so
       // navigateToApp must not fire.
       expect(navigateToApp).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the source id, never the action label, when no name label exists', () => {
+      const namelessAlert: UnifiedAlertSummary = {
+        ...baseAlert,
+        datasourceType: 'opensearch',
+        labels: { monitor_id: 'mon-7' },
+      };
+      const { getByTestId } = render(
+        <AlertDetailFlyout
+          alert={namelessAlert}
+          datasources={datasources}
+          onClose={jest.fn()}
+          onAcknowledge={jest.fn()}
+        />
+      );
+      const sourceRow = getByTestId('alertDetailSourceRuleLink');
+      expect(sourceRow).toHaveTextContent('mon-7');
+      expect(sourceRow).not.toHaveTextContent('Open rule');
     });
   });
 

--- a/public/components/alerting/__tests__/alert_detail_flyout.test.tsx
+++ b/public/components/alerting/__tests__/alert_detail_flyout.test.tsx
@@ -449,6 +449,29 @@ describe('AlertDetailFlyout', () => {
       });
     });
 
+    it('prefers the SLO name over a copied monitor_name for an SLO alert', () => {
+      // An SLO alert that also carries a monitor_name must still name the SLO in
+      // the "Source SLO" row — not the monitor — to stay consistent with the
+      // "Open SLO" action.
+      const sloAlert: UnifiedAlertSummary = {
+        ...baseAlert,
+        datasourceType: 'prometheus',
+        labels: { slo_id: 'slo-1', slo_name: 'API availability', monitor_name: 'High latency' },
+      };
+      const { getByText, getByTestId } = render(
+        <AlertDetailFlyout
+          alert={sloAlert}
+          datasources={datasources}
+          onClose={jest.fn()}
+          onAcknowledge={jest.fn()}
+        />
+      );
+      expect(getByText('Source SLO')).toBeInTheDocument();
+      const sourceRow = getByTestId('alertDetailSourceRuleLink');
+      expect(sourceRow).toHaveTextContent('API availability');
+      expect(sourceRow).not.toHaveTextContent('High latency');
+    });
+
     it('does not cross apps for a monitor rule deep-link', () => {
       const monitorAlert: UnifiedAlertSummary = {
         ...baseAlert,

--- a/public/components/alerting/__tests__/alerts_dashboard.test.tsx
+++ b/public/components/alerting/__tests__/alerts_dashboard.test.tsx
@@ -424,4 +424,82 @@ describe('AlertsDashboard', () => {
     expect(onDatasourceChange).toHaveBeenCalledWith([]);
     expect(searchInput.value).toBe('');
   });
+
+  // B1 / A11Y1 + CLAR2: severity must be conveyed by a labeled indicator
+  // (translated text), not a bare color dot. Reverting to the dot removes the
+  // human-readable "Critical" text and this fails.
+  it('renders severity as a labeled badge, not a bare color dot', () => {
+    render(<AlertsDashboard {...baseProps} alerts={[sampleAlert]} />);
+    const badge = screen.getByTestId('alertSeverityBadge');
+    expect(badge).toHaveTextContent('Critical');
+    // The raw lowercase wire enum must not leak into the table cell.
+    expect(badge).not.toHaveTextContent('critical');
+  });
+
+  // CLAR2: the State column routes the raw enum through getStateLabel, so it
+  // reads "Active" rather than the lowercase wire value `active`.
+  it('renders the alert state as a human label in the table', () => {
+    render(<AlertsDashboard {...baseProps} alerts={[sampleAlert]} />);
+    // The facet still lists the raw `active` option; the table cell shows "Active".
+    const table = within(screen.getByRole('table'));
+    expect(table.getByText('Active')).toBeInTheDocument();
+  });
+
+  // CLAR4: a single empty placeholder (EMPTY_VALUE = '—') everywhere. The old
+  // Started-cell glyph was '---'; reintroducing it fails this test.
+  it('uses a single unified empty placeholder and never the legacy --- glyph', () => {
+    const emptyAlert: UnifiedAlertSummary = {
+      ...sampleAlert,
+      id: 'empty-1',
+      name: 'EmptyFields',
+      message: undefined,
+      startTime: '',
+      lastUpdated: '',
+    };
+    render(<AlertsDashboard {...baseProps} alerts={[emptyAlert]} />);
+    const table = within(screen.getByRole('table'));
+    // Message, Started, and Duration cells all collapse to the em dash.
+    expect(table.getAllByText('—').length).toBeGreaterThan(0);
+    // The legacy triple-hyphen glyph must be gone.
+    expect(table.queryByText('---')).toBeNull();
+  });
+
+  // A11Y4: the grouped-anomaly expand toggle exposes its state via
+  // aria-expanded, and flips it on toggle.
+  it('sets aria-expanded on the anomaly occurrences toggle in both states', () => {
+    render(
+      <AlertsDashboard
+        {...baseProps}
+        alerts={[
+          buildAnomaly({ id: 'ad-a', startTime: '2026-06-04T21:03:00.000Z' }),
+          buildAnomaly({ id: 'ad-b', startTime: '2026-06-04T22:03:00.000Z' }),
+        ]}
+      />
+    );
+    const toggle = screen.getByLabelText('Show or hide grouped anomaly occurrences');
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.click(toggle);
+    expect(
+      screen.getByLabelText('Show or hide grouped anomaly occurrences')
+    ).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  // OBS1: a deep link (`#/alerts?q=...`) seeds the search box on first render,
+  // and the user can still type over it afterwards.
+  it('seeds the search box from initialSearchQuery without blocking later input', () => {
+    render(
+      <AlertsDashboard
+        {...baseProps}
+        alerts={[sampleAlert]}
+        initialSearchQuery="HighCPU"
+      />
+    );
+    const searchInput = screen.getByLabelText('Search alerts') as HTMLInputElement;
+    expect(searchInput.value).toBe('HighCPU');
+    // Seeded query actually filters the table down to the match.
+    expect(screen.getByText('HighCPU')).toBeInTheDocument();
+    // Subsequent typing is honored — the seed does not re-apply and overwrite it.
+    fireEvent.change(searchInput, { target: { value: 'something-else' } });
+    expect(searchInput.value).toBe('something-else');
+  });
 });

--- a/public/components/alerting/__tests__/alerts_dashboard.test.tsx
+++ b/public/components/alerting/__tests__/alerts_dashboard.test.tsx
@@ -479,21 +479,16 @@ describe('AlertsDashboard', () => {
     const toggle = screen.getByLabelText('Show or hide grouped anomaly occurrences');
     expect(toggle).toHaveAttribute('aria-expanded', 'false');
     fireEvent.click(toggle);
-    expect(
-      screen.getByLabelText('Show or hide grouped anomaly occurrences')
-    ).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByLabelText('Show or hide grouped anomaly occurrences')).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
   });
 
   // OBS1: a deep link (`#/alerts?q=...`) seeds the search box on first render,
   // and the user can still type over it afterwards.
   it('seeds the search box from initialSearchQuery without blocking later input', () => {
-    render(
-      <AlertsDashboard
-        {...baseProps}
-        alerts={[sampleAlert]}
-        initialSearchQuery="HighCPU"
-      />
-    );
+    render(<AlertsDashboard {...baseProps} alerts={[sampleAlert]} initialSearchQuery="HighCPU" />);
     const searchInput = screen.getByLabelText('Search alerts') as HTMLInputElement;
     expect(searchInput.value).toBe('HighCPU');
     // Seeded query actually filters the table down to the match.

--- a/public/components/alerting/__tests__/linkify_annotation.test.tsx
+++ b/public/components/alerting/__tests__/linkify_annotation.test.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { LinkifyAnnotation, isSafeHttpUrl } from '../linkify_annotation';
+
+describe('isSafeHttpUrl', () => {
+  it('accepts http and https URLs', () => {
+    expect(isSafeHttpUrl('http://runbooks.example/api')).toBe(true);
+    expect(isSafeHttpUrl('https://runbooks.example/api?x=1#frag')).toBe(true);
+  });
+
+  it('rejects non-URL plain text', () => {
+    expect(isSafeHttpUrl('see the wiki')).toBe(false);
+    expect(isSafeHttpUrl('www.example.com')).toBe(false);
+    expect(isSafeHttpUrl('')).toBe(false);
+  });
+
+  it('rejects unsafe / non-http schemes', () => {
+    // eslint-disable-next-line no-script-url
+    expect(isSafeHttpUrl('javascript:alert(1)')).toBe(false);
+    expect(isSafeHttpUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
+    expect(isSafeHttpUrl('file:///etc/passwd')).toBe(false);
+    expect(isSafeHttpUrl('ftp://host/file')).toBe(false);
+  });
+});
+
+describe('LinkifyAnnotation', () => {
+  it('renders a safe URL as an external link', () => {
+    const { getByText } = render(
+      <LinkifyAnnotation value="https://runbooks.example/api" data-test-subj="v" />
+    );
+    const link = getByText('https://runbooks.example/api');
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('href', 'https://runbooks.example/api');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', expect.stringContaining('noreferrer'));
+  });
+
+  it('renders plain text (not a link) for non-URL values', () => {
+    const { getByText } = render(<LinkifyAnnotation value="oncall handbook" data-test-subj="v" />);
+    const node = getByText('oncall handbook');
+    expect(node.tagName).not.toBe('A');
+  });
+
+  it('does not linkify unsafe schemes', () => {
+    // eslint-disable-next-line no-script-url
+    const value = 'javascript:alert(1)';
+    const { getByText } = render(<LinkifyAnnotation value={value} data-test-subj="v" />);
+    const node = getByText(value);
+    expect(node.tagName).not.toBe('A');
+  });
+
+  it('renders the fallback for empty values', () => {
+    const { getByText } = render(<LinkifyAnnotation value="" fallback="—" data-test-subj="v" />);
+    expect(getByText('—')).toBeInTheDocument();
+  });
+});

--- a/public/components/alerting/__tests__/linkify_annotation.test.tsx
+++ b/public/components/alerting/__tests__/linkify_annotation.test.tsx
@@ -58,4 +58,13 @@ describe('LinkifyAnnotation', () => {
     const { getByText } = render(<LinkifyAnnotation value="" fallback="—" data-test-subj="v" />);
     expect(getByText('—')).toBeInTheDocument();
   });
+
+  it('trims whitespace-padded plain text (consistent with the link path)', () => {
+    const { getByTestId } = render(
+      <LinkifyAnnotation value="  oncall handbook  " data-test-subj="v" />
+    );
+    const node = getByTestId('v');
+    expect(node.tagName).not.toBe('A');
+    expect(node.textContent).toBe('oncall handbook');
+  });
 });

--- a/public/components/alerting/__tests__/monitors_table.test.tsx
+++ b/public/components/alerting/__tests__/monitors_table.test.tsx
@@ -247,8 +247,11 @@ describe('MonitorsTable', () => {
 
     it('renders the pending badge instead of the status health pill', () => {
       const { container } = render(<MonitorsTable {...defaultProps} rules={[pendingRule()]} />);
-      expect(container.querySelector('[data-test-subj="pendingRuleBadge"]')).toBeInTheDocument();
-      expect(screen.getByText('Pending')).toBeInTheDocument();
+      const badge = container.querySelector('[data-test-subj="pendingRuleBadge"]');
+      expect(badge).toBeInTheDocument();
+      // Scope to the badge: the Status facet now title-cases its options too, so a
+      // bare getByText('Pending') would also match the "Pending" facet label.
+      expect(badge).toHaveTextContent('Pending');
     });
 
     it('disables the checkbox for a pending row (not selectable)', () => {

--- a/public/components/alerting/alarms_page.tsx
+++ b/public/components/alerting/alarms_page.tsx
@@ -1625,6 +1625,7 @@ export const AlarmsPage: React.FC<AlarmsPageProps> = ({
             onTimeChange={handleTimeChange}
             onRefresh={handleRefreshTime}
             datasourceErrorMap={datasourceErrorMapByName}
+            initialSearchQuery={deepLink.q}
           />
         </>
       );

--- a/public/components/alerting/alert_detail_flyout.tsx
+++ b/public/components/alerting/alert_detail_flyout.tsx
@@ -31,8 +31,11 @@ import {
 import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
 import { UnifiedAlert, UnifiedAlertSummary, Datasource } from '../../../common/types/alerting';
+import { observabilityApmSloID } from '../../../common/constants/apm';
+import { coreRefs } from '../../framework/core_refs';
 import { AnomalyDetailContent } from './anomaly_detail_flyout';
 import { AlertingOpenSearchService } from './query_services/alerting_opensearch_service';
+import { LinkifyAnnotation } from './linkify_annotation';
 import { SEVERITY_COLORS, STATE_COLORS } from './shared_constants';
 
 /** Internal label keys filtered from the Labels accordion display. */
@@ -143,48 +146,52 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
   const dsName =
     datasources.find((d) => d.id === alert.datasourceId)?.name || alert.datasourceId || '\u2014';
   // Memoize so `allLabels` keeps a stable reference between renders when
-  // `alertData.labels` is unchanged \u2014 the `useMemo` for `sourceLinkPath`
+  // `alertData.labels` is unchanged \u2014 the `useMemo` for `sourceLink`
   // below depends on it, and a fresh `{}` from the `||` fallback would
   // otherwise re-run the dep-list check every render.
   const allLabels = useMemo(() => alertData.labels || {}, [alertData.labels]);
 
-  // Source-rule deep-link computation (BUG-14). The unified alert shape
-  // doesn't carry a typed pointer to the originating monitor; we derive
-  // one from the labels available per-backend:
-  //   - OpenSearch alerts: `labels.monitor_id` is reliably populated.
-  //     Match on `monitor_id:<id>` so the Rules tab's `matchesSearch`
-  //     narrows to the originating monitor (rules carry the same id).
-  //   - Prometheus alerts: no `monitor_*` label exists; the closest
-  //     stable handle is `labels.alertname` (Prom convention) which
-  //     equals the rule's `name`. Match by name.
-  // SLO burn-rate alerts (Prometheus side) carry `slo_id` \u2014 match on
-  // that label so the Rules tab narrows to the burn-rate group rather
-  // than just the single firing tier.
-  // Falls back to undefined when no usable handle exists, in which case
-  // the source-link surfaces are simply not rendered. Includes the
-  // backing datasource id (`ds=\u2026`) so the Rules tab DS filter
-  // auto-selects the right cluster on landing \u2014 same mechanism as the
-  // SLO detail "View alert rules" deep-link (BUG-12).
-  const sourceLinkPath = useMemo(() => {
+  // Source deep-link computation (BUG-14 / OBS1). The unified alert shape
+  // doesn't carry a typed pointer to its origin; we derive a navigation
+  // target from the labels available per-backend. The target is an object so
+  // each surface knows whether it must cross an OSD app boundary (`appId`)
+  // or can stay within the alerting app (hash-only):
+  //   - SLO burn-rate alerts (either backend) carry `slo_id`. These open the
+  //     SLO *detail* page, which lives in the separate SLO app
+  //     (`observabilityApmSloID`) \u2014 so carry that app id and point at
+  //     `#/slos/<id>` (matches the SLO listing/detail deep-link convention).
+  //     Checked first, and backend-agnostically, so it stays in lock-step
+  //     with `sourceLinkLabel` below (which shows "Open SLO" whenever
+  //     `slo_id` is present).
+  //   - OpenSearch alerts: `labels.monitor_id` is reliably populated. Match
+  //     on `monitor_id:<id>` so the Rules tab's `matchesSearch` narrows to
+  //     the originating monitor (rules carry the same id).
+  //   - Prometheus alerts: no `monitor_*` label exists; the closest stable
+  //     handle is `labels.alertname` (Prom convention) which equals the
+  //     rule's `name`. Match by name.
+  // Falls back to undefined when no usable handle exists, in which case the
+  // source-link surfaces are simply not rendered. Rules deep-links include
+  // the backing datasource id (`ds=\u2026`) so the Rules tab DS filter
+  // auto-selects the right cluster on landing (BUG-12).
+  const sourceLink = useMemo<{ path: string; appId?: string } | undefined>(() => {
     const dsId = alert.datasourceId;
     if (!dsId) return undefined;
     const labels = (allLabels as Record<string, string>) ?? {};
+    const sloId = labels.slo_id;
+    if (sloId) {
+      return { path: `#/slos/${encodeURIComponent(sloId)}`, appId: observabilityApmSloID };
+    }
     if (alert.datasourceType === 'opensearch') {
       const monitorId = labels.monitor_id;
       if (!monitorId) return undefined;
       const params = new URLSearchParams({ q: `monitor_id:${monitorId}`, ds: dsId });
-      return `#/rules?${params.toString()}`;
+      return { path: `#/rules?${params.toString()}` };
     }
     if (alert.datasourceType === 'prometheus') {
-      const sloId = labels.slo_id;
-      if (sloId) {
-        const params = new URLSearchParams({ q: `slo_id:${sloId}`, ds: dsId });
-        return `#/rules?${params.toString()}`;
-      }
       const alertname = labels.alertname;
       if (!alertname) return undefined;
       const params = new URLSearchParams({ q: alertname, ds: dsId });
-      return `#/rules?${params.toString()}`;
+      return { path: `#/rules?${params.toString()}` };
     }
     return undefined;
   }, [alert.datasourceId, alert.datasourceType, allLabels]);
@@ -199,13 +206,24 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
       });
 
   const navigateToSource = () => {
-    if (!sourceLinkPath) return;
-    // Same-app navigation: directly update the hash and dispatch a
-    // synthetic hashchange event so the AlarmsPage listener picks it up.
-    // Setting window.location.hash alone doesn't fire the event when
-    // called programmatically from within the same page.
+    if (!sourceLink) return;
     onClose();
-    window.location.hash = sourceLinkPath;
+    if (sourceLink.appId) {
+      // Cross-app navigation: the SLO detail page lives in a different OSD
+      // application than the alerting app, so go through
+      // `application.navigateToApp` to switch apps (workspace-aware), then
+      // fire a synthetic hashchange for the target app's HashRouter to pick
+      // up the route \u2014 navigateToApp uses pushState, which does not emit
+      // hashchange on its own.
+      coreRefs?.application?.navigateToApp(sourceLink.appId, { path: sourceLink.path });
+      window.dispatchEvent(new HashChangeEvent('hashchange'));
+      return;
+    }
+    // Same-app navigation: directly update the hash and dispatch a synthetic
+    // hashchange event so the AlarmsPage listener picks it up. Setting
+    // window.location.hash alone doesn't fire the event when called
+    // programmatically from within the same page.
+    window.location.hash = sourceLink.path;
     window.dispatchEvent(new HashChangeEvent('hashchange'));
   };
 
@@ -260,7 +278,7 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
               <EuiFlexItem grow={false}>
                 <EuiBadge color={SEVERITY_COLORS[alert.severity]}>{alert.severity}</EuiBadge>
               </EuiFlexItem>
-              {sourceLinkPath && (
+              {sourceLink && (
                 <EuiFlexItem grow={false}>
                   <EuiButton
                     size="s"
@@ -362,7 +380,7 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
                 }),
                 description: getAlertDuration(alert.startTime),
               },
-              ...(sourceLinkPath
+              ...(sourceLink
                 ? [
                     {
                       title: i18n.translate('observability.alerting.alertDetailFlyout.sourceRule', {
@@ -469,7 +487,9 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
               compressed
               listItems={Object.entries(annotations).map(([k, v]) => ({
                 title: k,
-                description: v || '\u2014',
+                // Annotations often hold runbook URLs \u2014 render them clickable
+                // (safe http/https only) instead of plain text (SRE2).
+                description: <LinkifyAnnotation value={v} />,
               }))}
             />
           ) : (

--- a/public/components/alerting/alert_detail_flyout.tsx
+++ b/public/components/alerting/alert_detail_flyout.tsx
@@ -196,13 +196,36 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
     return undefined;
   }, [alert.datasourceId, alert.datasourceType, allLabels]);
 
-  const monitorDisplayName = (allLabels as Record<string, string>)?.monitor_name;
-  const sourceLinkLabel = (allLabels as Record<string, string>)?.slo_id
+  const sloId = (allLabels as Record<string, string>)?.slo_id;
+  const sourceLinkLabel = sloId
     ? i18n.translate('observability.alerting.alertDetailFlyout.openSlo', {
         defaultMessage: 'Open SLO',
       })
     : i18n.translate('observability.alerting.alertDetailFlyout.openMonitor', {
         defaultMessage: 'Open rule',
+      });
+
+  // The description-list row names the *source*, so it must never fall back to
+  // the action label (`sourceLinkLabel`) — that both duplicates the header
+  // button verbatim and mislabels an SLO as if "Open SLO" were its name.
+  // Preference order per backend: the monitor's own name (OpenSearch), the SLO
+  // name then its id (SLO burn-rate alerts, both carry `slo_name`/`slo_id` per
+  // `slo_promql_generator`), then the Prometheus `alertname`, then the raw
+  // `monitor_id`. `sourceLink` only exists when one of `slo_id` / `monitor_id` /
+  // `alertname` is present, so this chain always resolves to a string.
+  const labelRecord = allLabels as Record<string, string>;
+  const sourceDisplayName =
+    labelRecord?.monitor_name ??
+    labelRecord?.slo_name ??
+    sloId ??
+    labelRecord?.alertname ??
+    labelRecord?.monitor_id;
+  const sourceRowTitle = sloId
+    ? i18n.translate('observability.alerting.alertDetailFlyout.sourceSlo', {
+        defaultMessage: 'Source SLO',
+      })
+    : i18n.translate('observability.alerting.alertDetailFlyout.sourceRule', {
+        defaultMessage: 'Source rule',
       });
 
   const navigateToSource = () => {
@@ -383,15 +406,13 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
               ...(sourceLink
                 ? [
                     {
-                      title: i18n.translate('observability.alerting.alertDetailFlyout.sourceRule', {
-                        defaultMessage: 'Source rule',
-                      }),
+                      title: sourceRowTitle,
                       description: (
                         <EuiLink
                           onClick={navigateToSource}
                           data-test-subj="alertDetailSourceRuleLink"
                         >
-                          {monitorDisplayName ?? sourceLinkLabel}
+                          {sourceDisplayName}
                         </EuiLink>
                       ),
                     },

--- a/public/components/alerting/alert_detail_flyout.tsx
+++ b/public/components/alerting/alert_detail_flyout.tsx
@@ -298,7 +298,9 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
           <EuiFlexItem grow={false}>
             <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
               <EuiFlexItem grow={false}>
-                <EuiHealth color={STATE_COLORS[alert.state]}>{getStateLabel(alert.state)}</EuiHealth>
+                <EuiHealth color={STATE_COLORS[alert.state]}>
+                  {getStateLabel(alert.state)}
+                </EuiHealth>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
                 <EuiBadge color={SEVERITY_COLORS[alert.severity]}>

--- a/public/components/alerting/alert_detail_flyout.tsx
+++ b/public/components/alerting/alert_detail_flyout.tsx
@@ -37,6 +37,8 @@ import { AnomalyDetailContent } from './anomaly_detail_flyout';
 import { AlertingOpenSearchService } from './query_services/alerting_opensearch_service';
 import { LinkifyAnnotation } from './linkify_annotation';
 import { SEVERITY_COLORS, STATE_COLORS } from './shared_constants';
+import { EMPTY_VALUE, getSeverityLabel, getStateLabel } from './enum_labels';
+import { formatTimestamp } from './time_format';
 
 /** Internal label keys filtered from the Labels accordion display. */
 const INTERNAL_LABEL_KEYS = new Set([
@@ -296,10 +298,12 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
           <EuiFlexItem grow={false}>
             <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false}>
               <EuiFlexItem grow={false}>
-                <EuiHealth color={STATE_COLORS[alert.state]}>{alert.state}</EuiHealth>
+                <EuiHealth color={STATE_COLORS[alert.state]}>{getStateLabel(alert.state)}</EuiHealth>
               </EuiFlexItem>
               <EuiFlexItem grow={false}>
-                <EuiBadge color={SEVERITY_COLORS[alert.severity]}>{alert.severity}</EuiBadge>
+                <EuiBadge color={SEVERITY_COLORS[alert.severity]}>
+                  {getSeverityLabel(alert.severity)}
+                </EuiBadge>
               </EuiFlexItem>
               {sourceLink && (
                 <EuiFlexItem grow={false}>
@@ -355,25 +359,25 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
                 title: i18n.translate('observability.alerting.alertDetailFlyout.alertId', {
                   defaultMessage: 'Alert ID',
                 }),
-                description: alert.id || '\u2014',
+                description: alert.id || EMPTY_VALUE,
               },
               {
                 title: i18n.translate('observability.alerting.alertDetailFlyout.state', {
                   defaultMessage: 'State',
                 }),
-                description: alert.state || '\u2014',
+                description: getStateLabel(alert.state),
               },
               {
                 title: i18n.translate('observability.alerting.alertDetailFlyout.severity', {
                   defaultMessage: 'Severity',
                 }),
-                description: alert.severity || '\u2014',
+                description: getSeverityLabel(alert.severity),
               },
               {
                 title: i18n.translate('observability.alerting.alertDetailFlyout.backend', {
                   defaultMessage: 'Backend',
                 }),
-                description: alert.datasourceType || '\u2014',
+                description: alert.datasourceType || EMPTY_VALUE,
               },
               {
                 title: i18n.translate('observability.alerting.alertDetailFlyout.datasource', {
@@ -385,17 +389,16 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
                 title: i18n.translate('observability.alerting.alertDetailFlyout.started', {
                   defaultMessage: 'Started',
                 }),
-                description: alert.startTime
-                  ? new Date(alert.startTime).toLocaleString()
-                  : '\u2014',
+                // Zone-labelled so this reads identically to the Started column in
+                // the alerts table; a bare `toLocaleString()` hides which zone it
+                // rendered in, so two readers see different "start" times.
+                description: formatTimestamp(alert.startTime),
               },
               {
                 title: i18n.translate('observability.alerting.alertDetailFlyout.lastUpdated', {
                   defaultMessage: 'Last Updated',
                 }),
-                description: alert.lastUpdated
-                  ? new Date(alert.lastUpdated).toLocaleString()
-                  : '\u2014',
+                description: formatTimestamp(alert.lastUpdated),
               },
               {
                 title: i18n.translate('observability.alerting.alertDetailFlyout.duration', {

--- a/public/components/alerting/alert_detail_flyout.tsx
+++ b/public/components/alerting/alert_detail_flyout.tsx
@@ -210,18 +210,18 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
   // The description-list row names the *source*, so it must never fall back to
   // the action label (`sourceLinkLabel`) — that both duplicates the header
   // button verbatim and mislabels an SLO as if "Open SLO" were its name.
-  // Preference order per backend: the monitor's own name (OpenSearch), the SLO
-  // name then its id (SLO burn-rate alerts, both carry `slo_name`/`slo_id` per
-  // `slo_promql_generator`), then the Prometheus `alertname`, then the raw
-  // `monitor_id`. `sourceLink` only exists when one of `slo_id` / `monitor_id` /
-  // `alertname` is present, so this chain always resolves to a string.
+  // Preference order per backend: SLO burn-rate alerts (any `slo_id`, matching
+  // the "Source SLO" title and "Open SLO" action) resolve to the SLO name then
+  // its id first — never the copied `monitor_name`, which would otherwise render
+  // a monitor's name in a row titled "Source SLO". Non-SLO alerts prefer the
+  // monitor's own name (OpenSearch), then the Prometheus `alertname`, then the
+  // raw `monitor_id`. `sourceLink` only exists when one of `slo_id` /
+  // `monitor_id` / `alertname` is present, so this chain always resolves to a
+  // string.
   const labelRecord = allLabels as Record<string, string>;
-  const sourceDisplayName =
-    labelRecord?.monitor_name ??
-    labelRecord?.slo_name ??
-    sloId ??
-    labelRecord?.alertname ??
-    labelRecord?.monitor_id;
+  const sourceDisplayName = sloId
+    ? (labelRecord?.slo_name ?? sloId)
+    : (labelRecord?.monitor_name ?? labelRecord?.alertname ?? labelRecord?.monitor_id);
   const sourceRowTitle = sloId
     ? i18n.translate('observability.alerting.alertDetailFlyout.sourceSlo', {
         defaultMessage: 'Source SLO',
@@ -239,9 +239,12 @@ export const AlertDetailFlyout: React.FC<AlertDetailFlyoutProps> = ({
       // `application.navigateToApp` to switch apps (workspace-aware), then
       // fire a synthetic hashchange for the target app's HashRouter to pick
       // up the route \u2014 navigateToApp uses pushState, which does not emit
-      // hashchange on its own.
-      coreRefs?.application?.navigateToApp(sourceLink.appId, { path: sourceLink.path });
-      window.dispatchEvent(new HashChangeEvent('hashchange'));
+      // hashchange on its own. Chain the dispatch off the returned promise so
+      // it fires after the target app has mounted, not while the source app's
+      // router is still active (dispatching synchronously races both routers).
+      Promise.resolve(
+        coreRefs?.application?.navigateToApp(sourceLink.appId, { path: sourceLink.path })
+      ).then(() => window.dispatchEvent(new HashChangeEvent('hashchange')));
       return;
     }
     // Same-app navigation: directly update the hash and dispatch a synthetic

--- a/public/components/alerting/alerts_dashboard.tsx
+++ b/public/components/alerting/alerts_dashboard.tsx
@@ -41,7 +41,7 @@ import {
 import { i18n } from '@osd/i18n';
 import { FormattedMessage } from '@osd/i18n/react';
 import { UnifiedAlertSummary, Datasource } from '../../../common/types/alerting';
-import { filterAlerts } from '../../../common/services/alerting/filter';
+import { alertMatchesSearch, filterAlerts } from '../../../common/services/alerting/filter';
 import { AlertTimeline } from './alerts_charts';
 import { FacetFilterGroup, useFacetCollapse } from './facet_filter_panel';
 import {
@@ -829,15 +829,7 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
 
   // Facet counts (against search-matched but not filter-matched alerts)
   const facetCounts = useMemo(() => {
-    const searchMatched = alerts.filter((a) => {
-      if (!searchQuery) return true;
-      const q = searchQuery.toLowerCase();
-      return (
-        a.name.toLowerCase().includes(q) ||
-        (a.message || '').toLowerCase().includes(q) ||
-        Object.values(a.labels).some((v) => v.toLowerCase().includes(q))
-      );
-    });
+    const searchMatched = alerts.filter((a) => alertMatchesSearch(a, searchQuery));
     const counts: Record<string, Record<string, number>> = {
       alertKind: {},
       severity: {},

--- a/public/components/alerting/alerts_dashboard.tsx
+++ b/public/components/alerting/alerts_dashboard.tsx
@@ -9,6 +9,7 @@
  */
 import React, { useState, useMemo } from 'react';
 import {
+  EuiBadge,
   EuiBasicTableColumn,
   EuiButton,
   EuiCard,
@@ -43,43 +44,29 @@ import { UnifiedAlertSummary, Datasource } from '../../../common/types/alerting'
 import { filterAlerts } from '../../../common/services/alerting/filter';
 import { AlertTimeline } from './alerts_charts';
 import { FacetFilterGroup, useFacetCollapse } from './facet_filter_panel';
-import { countBy, isStandardOpenSearchDatasource } from './shared_constants';
+import {
+  countBy,
+  isStandardOpenSearchDatasource,
+  SEVERITY_COLORS,
+  STATE_COLORS,
+} from './shared_constants';
+import { EMPTY_VALUE, getSeverityLabel, getStateLabel } from './enum_labels';
+import { formatTimestamp } from './time_format';
+import { ALERT_KIND_HEX, getStateHex } from './alert_colors';
 import { INTERNAL_LABEL_KEYS } from './monitors_table/monitors_table_helpers';
 import './alerting.scss';
 
 // ============================================================================
-// Color maps (used by table columns and filter panel)
+// Color / label maps
+//
+// Severity and state colors now come from the shared, theme-derived helpers
+// (`shared_constants.ts` for OUI semantic color *names* consumed by
+// `EuiBadge` / `EuiHealth`, `alert_colors.ts` for raw theme hex where a CSS
+// color is unavoidable). The former light-theme-only literal hex maps were
+// removed — they drifted from the shared source and rendered near-invisible
+// swatches in dark mode.
 // ============================================================================
 
-const SEVERITY_COLORS: Record<string, string> = {
-  critical: '#BD271E',
-  high: '#F5A700',
-  medium: '#006BB4',
-  low: '#98A2B3',
-  info: '#D3DAE6',
-};
-const STATE_COLORS: Record<string, string> = {
-  active: '#BD271E',
-  anomaly: '#B8821C',
-  pending: '#F5A700',
-  acknowledged: '#006BB4',
-  resolved: '#017D73',
-  error: '#BD271E',
-  silenced: '#98A2B3',
-};
-const STATE_HEALTH: Record<string, string> = {
-  active: 'danger',
-  anomaly: '#B8821C',
-  pending: 'warning',
-  acknowledged: 'primary',
-  resolved: 'success',
-  error: 'danger',
-  silenced: 'default',
-};
-const ALERT_TYPE_COLORS: Record<string, string> = {
-  alert: '#006BB4',
-  anomaly: '#B8821C',
-};
 const ALERTS_HIDDEN_LABEL_KEYS = new Set([
   ...Array.from(INTERNAL_LABEL_KEYS),
   'anomaly_result_id',
@@ -456,7 +443,7 @@ function formatAlertDuration(alert: UnifiedAlertSummary): string {
   if (getAlertKind(alert) === 'anomaly' && Number.isFinite(start) && Number.isFinite(end)) {
     return formatDurationBetween(start, end);
   }
-  return alert.startTime ? formatDuration(alert.startTime) : '—';
+  return alert.startTime ? formatDuration(alert.startTime) : EMPTY_VALUE;
 }
 
 function parseAnomalyNumber(value?: string): number | undefined {
@@ -466,7 +453,7 @@ function parseAnomalyNumber(value?: string): number | undefined {
 }
 
 function formatAnomalyMetric(value?: number): string {
-  return value === undefined ? '—' : value.toFixed(2);
+  return value === undefined ? EMPTY_VALUE : value.toFixed(2);
 }
 
 function formatEntityLabel(entity?: string): string {
@@ -513,7 +500,7 @@ function buildGroupedAnomalyRow(group: UnifiedAlertSummary[]): AlertTableRow {
       values: {
         count,
         maxGrade: formatAnomalyMetric(maxGrade),
-        latestTime: new Date(latest.lastUpdated || latest.startTime).toLocaleString(),
+        latestTime: formatTimestamp(latest.lastUpdated || latest.startTime),
       },
     }),
     groupedOccurrences: sorted,
@@ -636,9 +623,7 @@ function renderGroupedAnomalyOccurrences(
         <EuiFlexGroup direction="column" gutterSize="s">
           {occurrences.map((occurrence, index) => {
             const occurrenceNumber = total - index;
-            const timestamp = new Date(
-              occurrence.lastUpdated || occurrence.startTime
-            ).toLocaleString();
+            const timestamp = formatTimestamp(occurrence.lastUpdated || occurrence.startTime);
 
             return (
               <EuiFlexItem key={occurrence.id}>
@@ -674,7 +659,7 @@ function renderGroupedAnomalyOccurrences(
                     </div>
                     <div className="altGroupedOccurrenceCell">
                       <EuiToolTip content={timestamp}>
-                        <span style={{ fontSize: 12 }}>
+                        <span style={{ fontSize: 12 }} tabIndex={0} aria-label={timestamp}>
                           <FormattedMessage
                             id="observability.alerting.alertsDashboard.groupedAnomalyStartedAgo"
                             defaultMessage="{duration} ago"
@@ -756,6 +741,12 @@ export interface AlertsDashboardProps {
    * details.
    */
   datasourceErrorMap?: Record<string, string>;
+  /**
+   * Seeds the alerts search box on first render — used by deep links such as
+   * `#/alerts?q=slo_id:<id>` that expect the list to arrive pre-filtered. Applied
+   * as the initial value ONLY; it does not override the user's subsequent typing.
+   */
+  initialSearchQuery?: string;
 }
 
 export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
@@ -782,8 +773,12 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
   onTimeChange,
   onRefresh,
   datasourceErrorMap,
+  initialSearchQuery,
 }) => {
-  const [searchQuery, setSearchQuery] = useState('');
+  // Lazy initializer so the deep-link query seeds the box exactly once; later
+  // renders (e.g. under the resizable container's mouse-move re-renders) must
+  // not clobber what the user has typed.
+  const [searchQuery, setSearchQuery] = useState(() => initialSearchQuery ?? '');
   const [filters, setFilters] = useState<AlertFilterState>(emptyAlertFilters());
   const { toggleFacetCollapse, isCollapsed: isFacetCollapsed } = useFacetCollapse();
   const [labelSearch, setLabelSearch] = useState('');
@@ -821,6 +816,16 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
   );
   const uniqueAlertKinds = useMemo(() => collectAlertUniqueValues(alerts, getAlertKind), [alerts]);
   const labelKeys = useMemo(() => collectAlertLabelKeys(alerts), [alerts]);
+
+  // The State facet includes the synthetic `anomaly` row kind, which has no
+  // semantic OUI color name in `STATE_COLORS`. Resolve every option through the
+  // theme-hex getter (which also covers `anomaly`) so `EuiHealth` renders a
+  // correct, dark-mode-safe swatch for each.
+  const stateFacetColorMap = useMemo(() => {
+    const map: Record<string, string> = {};
+    for (const state of uniqueStates) map[state] = getStateHex(state);
+    return map;
+  }, [uniqueStates]);
 
   // Facet counts (against search-matched but not filter-matched alerts)
   const facetCounts = useMemo(() => {
@@ -941,23 +946,19 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
     () => [
       {
         field: 'severity',
-        name: i18n.translate('observability.alerting.alertsDashboard.column.sev', {
-          defaultMessage: 'Sev',
+        name: i18n.translate('observability.alerting.alertsDashboard.column.severity', {
+          defaultMessage: 'Severity',
         }),
-        width: '60px',
+        width: '10%',
         sortable: (a: AlertTableRow) => SEVERITY_SORT_ORDER[a.severity] ?? 5,
+        // A labeled badge (not a bare color dot) so severity is conveyed by text
+        // and shape, not color alone — reachable by screen readers and legible
+        // to colorblind users. Mirrors the severity column in
+        // monitors_table/monitors_table_columns.tsx.
         render: (s: string) => (
-          <EuiToolTip content={s}>
-            <span
-              style={{
-                width: 10,
-                height: 10,
-                borderRadius: '50%',
-                background: SEVERITY_COLORS[s],
-                display: 'inline-block',
-              }}
-            />
-          </EuiToolTip>
+          <EuiBadge color={SEVERITY_COLORS[s] || 'default'} data-test-subj="alertSeverityBadge">
+            {getSeverityLabel(s)}
+          </EuiBadge>
         ),
       },
       {
@@ -1017,6 +1018,7 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
                     flush="left"
                     color="text"
                     iconType={isExpanded ? 'arrowDown' : 'arrowRight'}
+                    aria-expanded={isExpanded}
                     onClick={(event) => {
                       event.stopPropagation();
                       toggleExpandedGroup();
@@ -1045,11 +1047,19 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
         name: i18n.translate('observability.alerting.alertsDashboard.column.state', {
           defaultMessage: 'State',
         }),
-        width: '140px',
+        width: '12%',
         sortable: (alert: AlertTableRow) => getAlertDisplayState(alert),
+        // Route the raw lowercase wire enum through `getStateLabel` so the UI
+        // shows "Active" / "Acknowledged" rather than `active`. `anomaly` is a
+        // row kind (not an alert state) so it isn't in the semantic name map —
+        // fall back to its theme hex, which `EuiHealth` also accepts.
         render: (_state: string, alert: AlertTableRow) => {
           const state = getAlertDisplayState(alert);
-          return <EuiHealth color={STATE_HEALTH[state] || 'subdued'}>{state}</EuiHealth>;
+          return (
+            <EuiHealth color={STATE_COLORS[state] || getStateHex(state)}>
+              {getStateLabel(state)}
+            </EuiHealth>
+          );
         },
       },
       {
@@ -1058,25 +1068,44 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
           defaultMessage: 'Message',
         }),
         truncateText: true,
-        render: (msg: string) => (
-          <EuiText size="xs" color="subdued">
-            {msg || '—'}
-          </EuiText>
-        ),
+        // The cell truncates, so wrap it in a tooltip that exposes the full
+        // message on hover / focus. The span is focusable (tabIndex) so
+        // keyboard users can reach the tooltip too. The row's "View details"
+        // action still opens the flyout for the complete record.
+        render: (msg: string) => {
+          if (!msg) {
+            return (
+              <EuiText size="xs" color="subdued">
+                {EMPTY_VALUE}
+              </EuiText>
+            );
+          }
+          return (
+            <EuiToolTip content={msg}>
+              <EuiText size="xs" color="subdued" tabIndex={0} className="altAlertMessageText">
+                {msg}
+              </EuiText>
+            </EuiToolTip>
+          );
+        },
       },
       {
         field: 'startTime',
         name: i18n.translate('observability.alerting.alertsDashboard.column.started', {
           defaultMessage: 'Started',
         }),
-        width: '120px',
+        width: '14%',
         sortable: true,
+        // The absolute, timezone-labeled timestamp used to live only in a hover
+        // tooltip on a non-focusable span (A11Y6). It is now also exposed via
+        // `aria-label` and the span is keyboard-focusable, so screen-reader and
+        // keyboard users get the exact time, not just the relative "x ago".
         render: (ts: string) => {
-          if (!ts) return <EuiText size="xs">---</EuiText>;
-          const abs = new Date(ts).toLocaleString();
+          if (!ts) return <EuiText size="xs">{EMPTY_VALUE}</EuiText>;
+          const abs = formatTimestamp(ts);
           return (
             <EuiToolTip content={abs}>
-              <span style={{ fontSize: 12 }}>
+              <span style={{ fontSize: 12 }} tabIndex={0} aria-label={abs}>
                 <FormattedMessage
                   id="observability.alerting.alertsDashboard.startedAgo"
                   defaultMessage="{duration} ago"
@@ -1092,7 +1121,7 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
         name: i18n.translate('observability.alerting.alertsDashboard.column.duration', {
           defaultMessage: 'Duration',
         }),
-        width: '90px',
+        width: '9%',
         render: (_ts: string, alert: AlertTableRow) => (
           <EuiText size="xs">{formatAlertDuration(getRepresentativeAlert(alert))}</EuiText>
         ),
@@ -1101,7 +1130,7 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
         name: i18n.translate('observability.alerting.alertsDashboard.column.actions', {
           defaultMessage: 'Actions',
         }),
-        width: '150px',
+        width: '13%',
         render: (alert: AlertTableRow) => {
           const representative = getRepresentativeAlert(alert);
           return (
@@ -1133,6 +1162,15 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
                       }
                     )}
                     size="s"
+                    // Guarantee a >=24x24 pointer target (WCAG 2.5.8). Inline
+                    // styles win over OUI's compressed button stylesheet.
+                    style={{
+                      minWidth: 24,
+                      minHeight: 24,
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                    }}
                     onClick={() => onViewDetail(representative)}
                   />
                 </EuiToolTip>
@@ -1145,6 +1183,7 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
                       iconType="check"
                       size="xs"
                       color="primary"
+                      style={{ minWidth: 24, minHeight: 24 }}
                       onClick={() => onAcknowledge(alert.id)}
                     >
                       <FormattedMessage
@@ -1296,7 +1335,7 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
                   filters.alertKind,
                   (v) => updateFilter('alertKind', v),
                   facetCounts.counts.alertKind,
-                  ALERT_TYPE_COLORS
+                  ALERT_KIND_HEX
                 )}
                 {renderFacetGroup(
                   'severity',
@@ -1318,7 +1357,7 @@ export const AlertsDashboard: React.FC<AlertsDashboardProps> = ({
                   filters.state,
                   (v) => updateFilter('state', v),
                   facetCounts.counts.state,
-                  STATE_COLORS
+                  stateFacetColorMap
                 )}
                 {(() => {
                   const visibleLabelKeys = labelKeys.filter(

--- a/public/components/alerting/linkify_annotation.tsx
+++ b/public/components/alerting/linkify_annotation.tsx
@@ -1,0 +1,68 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Renders an annotation value as a clickable link when it is a safe URL, and
+ * as plain text otherwise. Alert/SLO annotations frequently hold runbook URLs;
+ * on-call engineers need to click through rather than copy-paste (SRE2).
+ *
+ * SECURITY: only `http:`/`https:` URLs are linkified. Any other scheme
+ * (`javascript:`, `data:`, `file:`, …) — or anything the `URL` constructor
+ * rejects — falls back to plain text so we never emit an executable link.
+ */
+
+import React from 'react';
+import { EuiLink } from '@elastic/eui';
+
+const EM_DASH = '—';
+
+/**
+ * True only for absolute `http:`/`https:` URLs. Parsing goes through the `URL`
+ * constructor (throws on relative/garbage input) so scheme validation is done
+ * on the parsed `protocol`, never on a string prefix.
+ */
+export function isSafeHttpUrl(value: string): boolean {
+  try {
+    const { protocol } = new URL(value);
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+export interface LinkifyAnnotationProps {
+  /** The raw annotation value. */
+  value?: string | null;
+  /** Rendered when the value is empty/whitespace. Defaults to an em dash. */
+  fallback?: string;
+  'data-test-subj'?: string;
+}
+
+export const LinkifyAnnotation: React.FC<LinkifyAnnotationProps> = ({
+  value,
+  fallback = EM_DASH,
+  'data-test-subj': dataTestSubj,
+}) => {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  if (!trimmed) {
+    return <span data-test-subj={dataTestSubj}>{fallback}</span>;
+  }
+  if (isSafeHttpUrl(trimmed)) {
+    // External links open in a new tab; `rel="noreferrer"` also implies
+    // `noopener`, so the opened runbook can't reach back through `window.opener`.
+    return (
+      <EuiLink
+        href={trimmed}
+        target="_blank"
+        rel="noreferrer"
+        external
+        data-test-subj={dataTestSubj}
+      >
+        {trimmed}
+      </EuiLink>
+    );
+  }
+  return <span data-test-subj={dataTestSubj}>{value}</span>;
+};

--- a/public/components/alerting/linkify_annotation.tsx
+++ b/public/components/alerting/linkify_annotation.tsx
@@ -64,5 +64,7 @@ export const LinkifyAnnotation: React.FC<LinkifyAnnotationProps> = ({
       </EuiLink>
     );
   }
-  return <span data-test-subj={dataTestSubj}>{value}</span>;
+  // Render `trimmed` (not raw `value`) so a whitespace-padded annotation reads
+  // identically whether or not it linkifies.
+  return <span data-test-subj={dataTestSubj}>{trimmed}</span>;
 };

--- a/public/components/alerting/monitors_table/__tests__/monitors_filters_panel.test.tsx
+++ b/public/components/alerting/monitors_table/__tests__/monitors_filters_panel.test.tsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { MonitorsFiltersPanel } from '../monitors_filters_panel';
+import { emptyFilters } from '../monitors_table_filters';
+
+// Minimal-but-complete props so the pure-render panel mounts. Only the Status /
+// Severity / Health facet wiring is under test here; everything else is inert.
+const makeProps = (overrides = {}) => ({
+  rules: [],
+  datasources: [],
+  selectedDsIds: [],
+  onDatasourceChange: jest.fn(),
+  maxDatasources: 5,
+  onDatasourceCapReached: jest.fn(),
+  datasourceErrorMap: {},
+  filters: emptyFilters(),
+  activeFilterCount: 0,
+  clearAllFilters: jest.fn(),
+  updateFilter: jest.fn(),
+  updateLabelFilter: jest.fn(),
+  labelKeys: [],
+  datasourceEntries: [],
+  uniqueStatuses: ['active', 'muted'],
+  uniqueSeverities: ['critical', 'medium'],
+  uniqueTypes: [],
+  uniqueHealth: ['healthy', 'no_data'],
+  uniqueCreators: [],
+  facetCounts: {
+    counts: {
+      status: { active: 3, muted: 2 },
+      severity: { critical: 1, medium: 4 },
+      monitorType: {},
+      healthStatus: { healthy: 4, no_data: 1 },
+      createdBy: {},
+    },
+    labelCounts: {},
+  },
+  isFacetCollapsed: () => false,
+  toggleFacetCollapse: jest.fn(),
+  onToggleOpen: jest.fn(),
+  savedSearches: [],
+  setSavedSearches: jest.fn(),
+  loadSavedSearch: jest.fn(),
+  deleteSavedSearch: jest.fn(),
+  showSaveSearchInput: false,
+  setShowSaveSearchInput: jest.fn(),
+  saveSearchName: '',
+  setSaveSearchName: jest.fn(),
+  saveCurrentSearch: jest.fn(),
+  searchQuery: '',
+  ...overrides,
+});
+
+describe('MonitorsFiltersPanel — facet labels match the table', () => {
+  // Regression guard: the Status/Severity/Health facet labels must read the
+  // same humanized text as the table cells (PR labelled those cells). If the
+  // facet still showed the raw token while the table showed Title Case, the two
+  // halves of the same screen would disagree — the defect this fixes.
+  it('renders humanized Status / Severity / Health facet labels, not raw tokens', () => {
+    const { getByText, queryByText } = render(<MonitorsFiltersPanel {...makeProps()} />);
+    expect(getByText('Active')).toBeInTheDocument();
+    expect(getByText('Muted')).toBeInTheDocument();
+    expect(getByText('Critical')).toBeInTheDocument();
+    expect(getByText('Medium')).toBeInTheDocument();
+    expect(getByText('Healthy')).toBeInTheDocument();
+    // The underscore token must not leak; it reads "No data".
+    expect(getByText('No data')).toBeInTheDocument();
+    expect(queryByText('no_data')).toBeNull();
+    // No raw lowercase enum survives as a visible facet label.
+    expect(queryByText('active')).toBeNull();
+    expect(queryByText('medium')).toBeNull();
+  });
+
+  it('still filters on the RAW value when a humanized facet is clicked (display-only map)', () => {
+    // The crucial invariant: relabelling must not change which rows match.
+    // Clicking the "Active" label must call updateFilter('status', ['active']).
+    const updateFilter = jest.fn();
+    const { getByText } = render(<MonitorsFiltersPanel {...makeProps({ updateFilter })} />);
+    fireEvent.click(getByText('Active'));
+    expect(updateFilter).toHaveBeenCalledWith('status', ['active']);
+
+    fireEvent.click(getByText('No data'));
+    expect(updateFilter).toHaveBeenCalledWith('healthStatus', ['no_data']);
+  });
+});

--- a/public/components/alerting/monitors_table/__tests__/monitors_table_columns.test.tsx
+++ b/public/components/alerting/monitors_table/__tests__/monitors_table_columns.test.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { buildTableColumns } from '../monitors_table_columns';
+import type { UnifiedRuleSummary } from '../../../../../common/types/alerting';
+
+const baseParams = {
+  filtered: [] as UnifiedRuleSummary[],
+  selectedIds: new Set<string>(),
+  columnWidths: {},
+  dsNameMap: new Map<string, string>(),
+  toggleSelect: jest.fn(),
+  toggleSelectAll: jest.fn(),
+  setSelectedMonitor: jest.fn(),
+};
+
+// Pull a single column's `render` out of the built column set by field name so
+// the tests exercise the exact cell renderer the table uses.
+const renderCell = (field: string, value: unknown) => {
+  const cols = buildTableColumns({
+    ...baseParams,
+    visibleColumns: new Set([field]),
+  });
+  const col = cols.find((c) => c.field === field) as
+    { render?: (v: unknown, item?: UnifiedRuleSummary) => React.ReactNode } | undefined;
+  if (!col?.render) throw new Error(`no render for column "${field}"`);
+  return render(<div>{col.render(value)}</div>);
+};
+
+describe('monitors_table_columns cell labels', () => {
+  // The alerts table reads "Active"/"Medium"/"Healthy"; before this change the
+  // rules table rendered the raw lowercase backend tokens next to it, so the
+  // same vocabulary read two different ways on adjacent tabs.
+  it('title-cases the status cell instead of showing the raw token', () => {
+    const { getByText, queryByText } = renderCell('status', 'active');
+    expect(getByText('Active')).toBeInTheDocument();
+    expect(queryByText('active')).toBeNull();
+  });
+
+  it('title-cases the severity cell', () => {
+    const { getByText, queryByText } = renderCell('severity', 'medium');
+    expect(getByText('Medium')).toBeInTheDocument();
+    expect(queryByText('medium')).toBeNull();
+  });
+
+  it('renders the health cell without leaking the no_data underscore', () => {
+    const { getByText, queryByText } = renderCell('healthStatus', 'no_data');
+    expect(getByText('No data')).toBeInTheDocument();
+    expect(queryByText('no_data')).toBeNull();
+  });
+
+  it('passes AD/forecaster lifecycle statuses through unchanged', () => {
+    // These arrive already display-ready; re-casing them would corrupt the
+    // wording, so the label getter must leave them alone.
+    const { getByText } = renderCell('status', 'Awaiting data to init');
+    expect(getByText('Awaiting data to init')).toBeInTheDocument();
+  });
+});

--- a/public/components/alerting/monitors_table/__tests__/monitors_table_columns.test.tsx
+++ b/public/components/alerting/monitors_table/__tests__/monitors_table_columns.test.tsx
@@ -28,7 +28,12 @@ const renderCell = (field: string, value: unknown) => {
   const col = cols.find((c) => c.field === field) as
     { render?: (v: unknown, item?: UnifiedRuleSummary) => React.ReactNode } | undefined;
   if (!col?.render) throw new Error(`no render for column "${field}"`);
-  return render(<div>{col.render(value)}</div>);
+  // The table always hands the cell renderer the row as the 2nd arg; the status
+  // renderer reads it to detect optimistic "pending" rows. Pass a minimal
+  // non-pending row (real id, so isPending() is false) so we exercise the
+  // label path the assertions below check.
+  const item = { status: value, id: 'rule-1' } as UnifiedRuleSummary;
+  return render(<div>{col.render(value, item)}</div>);
 };
 
 describe('monitors_table_columns cell labels', () => {

--- a/public/components/alerting/monitors_table/monitors_filters_panel.tsx
+++ b/public/components/alerting/monitors_table/monitors_filters_panel.tsx
@@ -38,6 +38,7 @@ import {
 } from '../../../../common/types/alerting';
 import { FacetFilterGroup } from '../facet_filter_panel';
 import { HEALTH_COLORS, SEVERITY_COLORS, STATUS_COLORS, TYPE_LABELS } from '../shared_constants';
+import { getMonitorStateLabel, getSeverityLabel } from '../enum_labels';
 import { collectLabelValues, FilterState } from './monitors_table_filters';
 import { INTERNAL_LABEL_KEYS, SavedSearch } from './monitors_table_helpers';
 
@@ -141,6 +142,25 @@ export const MonitorsFiltersPanel: React.FC<MonitorsFiltersPanelProps> = ({
     }
     return map;
   }, [datasources]);
+
+  // Display maps so the Status / Severity / Health facet labels read the same
+  // as the table cells (e.g. "Active", "Medium", "No data") instead of the raw
+  // backend tokens. Only the *label* is mapped — the facet still filters on the
+  // raw value (FacetFilterGroup's onChange keeps the original option), so this
+  // is display-only and cannot change which rows match. Mirrors how the Type
+  // facet already uses TYPE_LABELS.
+  const statusDisplayMap = useMemo(
+    () => Object.fromEntries(uniqueStatuses.map((s) => [s, getMonitorStateLabel(s)])),
+    [uniqueStatuses]
+  );
+  const severityDisplayMap = useMemo(
+    () => Object.fromEntries(uniqueSeverities.map((s) => [s, getSeverityLabel(s)])),
+    [uniqueSeverities]
+  );
+  const healthDisplayMap = useMemo(
+    () => Object.fromEntries(uniqueHealth.map((h) => [h, getMonitorStateLabel(h)])),
+    [uniqueHealth]
+  );
 
   // Render a single facet group (delegates to shared component)
   const renderFacetGroup = (
@@ -253,7 +273,7 @@ export const MonitorsFiltersPanel: React.FC<MonitorsFiltersPanelProps> = ({
           filters.status,
           (v) => updateFilter('status', v as MonitorStatus[]),
           facetCounts.counts.status,
-          undefined,
+          statusDisplayMap,
           STATUS_COLORS
         )}
         {renderFacetGroup(
@@ -265,7 +285,7 @@ export const MonitorsFiltersPanel: React.FC<MonitorsFiltersPanelProps> = ({
           filters.severity,
           (v) => updateFilter('severity', v as UnifiedAlertSeverity[]),
           facetCounts.counts.severity,
-          undefined,
+          severityDisplayMap,
           SEVERITY_COLORS
         )}
         {renderFacetGroup(
@@ -288,7 +308,7 @@ export const MonitorsFiltersPanel: React.FC<MonitorsFiltersPanelProps> = ({
           filters.healthStatus,
           (v) => updateFilter('healthStatus', v as MonitorHealthStatus[]),
           facetCounts.counts.healthStatus,
-          undefined,
+          healthDisplayMap,
           HEALTH_COLORS
         )}
         {renderFacetGroup(

--- a/public/components/alerting/monitors_table/monitors_table_columns.tsx
+++ b/public/components/alerting/monitors_table/monitors_table_columns.tsx
@@ -43,6 +43,7 @@ import {
   TYPE_LABELS,
 } from '../shared_constants';
 import { TruncatedLabel } from '../../common/truncated_label';
+import { getMonitorStateLabel, getSeverityLabel } from '../enum_labels';
 import { DEFAULT_WIDTHS } from './resizable_columns';
 import { isPending } from './pending_rules';
 
@@ -217,7 +218,9 @@ export function buildTableColumns({
               </EuiToolTip>
             );
           }
-          return <EuiHealth color={STATUS_COLORS[s] || 'subdued'}>{s}</EuiHealth>;
+          return (
+            <EuiHealth color={STATUS_COLORS[s] || 'subdued'}>{getMonitorStateLabel(s)}</EuiHealth>
+          );
         },
       });
     } else if (colId === 'severity') {
@@ -229,7 +232,7 @@ export function buildTableColumns({
         sortable: true,
         width: w('severity'),
         render: (s: UnifiedAlertSeverity) => (
-          <EuiBadge color={SEVERITY_COLORS[s] || 'default'}>{s}</EuiBadge>
+          <EuiBadge color={SEVERITY_COLORS[s] || 'default'}>{getSeverityLabel(s)}</EuiBadge>
         ),
       });
     } else if (colId === 'monitorType') {
@@ -251,7 +254,7 @@ export function buildTableColumns({
         sortable: true,
         width: w('healthStatus'),
         render: (h: MonitorHealthStatus) => (
-          <EuiHealth color={HEALTH_COLORS[h] || 'subdued'}>{h}</EuiHealth>
+          <EuiHealth color={HEALTH_COLORS[h] || 'subdued'}>{getMonitorStateLabel(h)}</EuiHealth>
         ),
       });
     } else if (colId === 'datasource') {

--- a/public/components/apm/pages/slos/__tests__/slo_metadata_panel.test.tsx
+++ b/public/components/apm/pages/slos/__tests__/slo_metadata_panel.test.tsx
@@ -117,6 +117,21 @@ describe('SloMetadataPanel', () => {
     expect(button!.getAttribute('aria-expanded')).toBe('false');
   });
 
+  it('renders a runbook-URL annotation value as a clickable external link (SRE2)', () => {
+    render(<SloMetadataPanel slo={makeSlo()} />);
+    // makeSlo() seeds `annotations: { runbook: 'https://runbooks.example/api' }`.
+    const link = screen.getByText('https://runbooks.example/api');
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('href', 'https://runbooks.example/api');
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  it('renders a non-URL annotation value as plain text, not a link', () => {
+    render(<SloMetadataPanel slo={makeSlo({ annotations: { note: 'ask oncall' } })} />);
+    const node = screen.getByText('ask oncall');
+    expect(node.tagName).not.toBe('A');
+  });
+
   it('renders empty-state text when labels, annotations, and exclusion windows are missing', () => {
     render(
       <SloMetadataPanel slo={makeSlo({ labels: {}, annotations: {}, exclusionWindows: [] })} />

--- a/public/components/apm/pages/slos/slo_metadata_panel.tsx
+++ b/public/components/apm/pages/slos/slo_metadata_panel.tsx
@@ -36,6 +36,7 @@ import {
   EuiToolTip,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
+import { LinkifyAnnotation } from '../../../alerting/linkify_annotation';
 import type {
   BudgetWarningThreshold,
   BurnRateConfig,
@@ -129,6 +130,11 @@ const ANNOTATION_COLUMNS: Array<EuiBasicTableColumn<{ key: string; value: string
       defaultMessage: 'Value',
     }),
     width: '70%',
+    // Annotation values are often runbook URLs — render them clickable (safe
+    // http/https only) rather than plain table text (SRE2).
+    render: (value: string) => (
+      <LinkifyAnnotation value={value} data-test-subj="slosDetailMetadataAnnotationValue" />
+    ),
   },
 ];
 


### PR DESCRIPTION
## Summary

Consolidates the three overlapping "unified Alerting a11y + theme + i18n" drafts — **#2827** (Alerts list), **#2825** (Alert flyout + SLO pivot), **#2839** (Rules-table + facet labels) — into a single branch rebased cleanly onto current `main`.

Those three were all cut from a shared base and **never rebased**, so they conflict with each other (and with `main`) on the shared primitives `alert_colors.ts` / `enum_labels.ts` / `time_format.ts`. Those primitives have since landed on `main` in a **superset** form (identical exports + extra `getMonitorStateLabel`), so this PR keeps `main`'s versions and re-applies only the **render-wiring** on top — no duplicate primitives.

## What this does
- **Alerts list** (`alerts_dashboard.tsx`): labeled severity badge (fixes the color-only WCAG 1.4.1 / 4.1.2 gap), Title-cased state, theme-aware colors via `getSeverityHex`/`getStateHex`, responsive columns; honors a `slo_id:<id>` label deep-link.
- **Alert flyout** (`alert_detail_flyout.tsx`): human-readable enums, timezone-aware timestamps, named alert source, linkified runbook annotations; adds `linkify_annotation.tsx`.
- **Rules table** (`monitors_table_columns.tsx`, `monitors_filters_panel.tsx`): Title-cases the Status/Severity/Health **cells and facet filters** to match the Alerts tab. Preserves `main`'s optimistic "pending" row badge.

## Visual evidence
BEFORE = `origin/main` (merge base), AFTER = this branch. Identical viewport (1440×900), route, data, and datasource selection in each pair.

### 1. Alerts list — severity is a labeled badge, not a color-only dot
![Alerts list before/after](https://raw.githubusercontent.com/lezzago/dashboards-observability/evidence/2879-alerts-a11y/pr-evidence/composite_1.png)

### 2. Alert detail flyout — human-readable enums + timezone-aware timestamps
![Alert flyout before/after](https://raw.githubusercontent.com/lezzago/dashboards-observability/evidence/2879-alerts-a11y/pr-evidence/composite_2.png)

### 3. Rules table & facets — Title-cased Status / Severity / Health
![Rules table before/after](https://raw.githubusercontent.com/lezzago/dashboards-observability/evidence/2879-alerts-a11y/pr-evidence/composite_3.png)

### Flow — walking Alerts list → alert detail → Rules table
| BEFORE (origin/main) | AFTER (this PR) |
|---|---|
| ![before flow](https://raw.githubusercontent.com/lezzago/dashboards-observability/evidence/2879-alerts-a11y/pr-evidence/before_flow.gif) | ![after flow](https://raw.githubusercontent.com/lezzago/dashboards-observability/evidence/2879-alerts-a11y/pr-evidence/after_flow.gif) |

## Supersedes (do NOT merge those)
Supersedes **#2827**, **#2825**, **#2839** — they will be **closed after this PR merges** (kept open until then so nothing is lost). This PR is the rebased, conflict-free union of all three.

## Testing
- Plugin Jest suite (`jest --config ./test/jest.config.js` over the alerting + apm/slos trees): **108 suites / 1173 tests pass**; full CI (build-linux/windows/macos, Lint, DCO, Cypress, FTR) green.
- `node scripts/eslint` clean on the hand-merged files.
- Two test helpers updated to match `main`'s pending-row status renderer (row `item` arg; badge-scoped "Pending" assertion).

## Notes for reviewers
- Opened as **draft**. Commit authorship from the original three PRs is preserved.
- Evidence media is hosted on a fork asset branch (`evidence/2879-alerts-a11y`), off the reviewable diff.
