### PR TITLE
fix(alerting): edit metrics flyout — Builder/Code toggle + overwrite guard (no expr data-loss)

### DIFF
--- a/public/components/alerting/__tests__/prometheus_form_sync.test.tsx
+++ b/public/components/alerting/__tests__/prometheus_form_sync.test.tsx
@@ -21,6 +21,14 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { PrometheusFormSection } from '../create_monitor/prometheus_form_section';
 import { parseExpr } from '../create_monitor/prom_query_builder';
 import type { PrometheusFormState } from '../create_monitor/create_monitor_types';
+import type { LabelEntry } from '../monitor_form_components';
+
+/** The subset of LabelEditor props the sync tests capture and assert against. */
+interface CapturedLabelEditorProps {
+  labels: LabelEntry[];
+  onChange: (labels: LabelEntry[]) => void;
+  context?: { service?: string; team?: string };
+}
 
 // Mock dependencies that PrometheusFormSection uses
 jest.mock('../monitor_form_components', () => ({
@@ -291,10 +299,10 @@ describe('PrometheusFormSection — rule group', () => {
 
   it('hides _ruleGroup from the label editor and preserves it through label edits', () => {
     const onUpdate = jest.fn();
-    const labelEditorProps: any[] = [];
+    const labelEditorProps: CapturedLabelEditorProps[] = [];
     // Capture what LabelEditor receives via the module mock
     const { LabelEditor } = jest.requireMock('../monitor_form_components');
-    LabelEditor.mockImplementation((props: any) => {
+    LabelEditor.mockImplementation((props: CapturedLabelEditorProps) => {
       labelEditorProps.push(props);
       return <div data-test-subj="label-editor" />;
     });
@@ -604,5 +612,26 @@ describe('PrometheusFormSection — Builder ⇄ Code toggle', () => {
     // preserved until the user actually picks a metric.
     fireEvent.click(screen.getByText('Builder'));
     expect(screen.getByTestId('prometheusBuilderOverwriteWarning')).toBeInTheDocument();
+  });
+
+  it('does not emit a query update when the Builder mounts with an unrepresentable expression', () => {
+    const onUpdate = jest.fn();
+    render(
+      <PrometheusFormSection
+        form={{ ...baseForm, query: complexExpr }}
+        onUpdate={onUpdate}
+        validationErrors={{}}
+        hasSubmitted={false}
+      />
+    );
+
+    // Toggle from the default Code mode into Builder, mounting PromQueryBuilder
+    // with a query parseExpr() can't represent. This is the guarantee the
+    // overwrite-warning callout promises: the builder seeds inert and must NOT
+    // emit onQueryChange on mount — the hand-written expression is preserved
+    // until the user actually picks a metric.
+    fireEvent.click(screen.getByText('Builder'));
+    expect(screen.getByText('Metric')).toBeInTheDocument();
+    expect(onUpdate).not.toHaveBeenCalledWith('query', expect.anything());
   });
 });

--- a/public/components/alerting/__tests__/prometheus_form_sync.test.tsx
+++ b/public/components/alerting/__tests__/prometheus_form_sync.test.tsx
@@ -6,10 +6,11 @@
 /**
  * Tests for the Prometheus form section (simplified Create Rule flyout).
  *
- * The form is builder-only: the PromQL query assembled from the metric and
- * label filters is the complete alert expression. There is no Code mode,
- * Trigger condition, or per-rule evaluation settings (those are rule-group
- * concerns in managed Prometheus).
+ * The Query section offers a Builder ⇄ Code toggle: the point-and-click builder
+ * OR a raw PromQL expression (the complete alert condition). An existing rule
+ * the builder can't represent opens in Code so it is never silently clobbered.
+ * There is still no Trigger condition or per-rule evaluation settings (those are
+ * rule-group concerns in managed Prometheus).
  *
  * Note: label-based queries (getByLabelText) are unreliable here because the
  * test environment stubs htmlIdGenerator, giving every form control the same
@@ -86,7 +87,7 @@ describe('PrometheusFormSection — simplified layout', () => {
     expect(screen.getByText('up')).toBeInTheDocument();
   });
 
-  it('does not render Code mode, Trigger condition, or Evaluation Settings', () => {
+  it('renders the Builder/Code toggle but not Trigger condition or Evaluation Settings', () => {
     render(
       <PrometheusFormSection
         form={baseForm}
@@ -96,7 +97,11 @@ describe('PrometheusFormSection — simplified layout', () => {
       />
     );
 
-    expect(screen.queryByText('Code')).not.toBeInTheDocument();
+    // The Builder ⇄ Code toggle is present (so a builder-unrepresentable rule
+    // can be edited as raw PromQL instead of a blank builder).
+    expect(screen.getByTestId('prometheusQueryModeToggle')).toBeInTheDocument();
+    // ...but the query-driven simplifications still apply: no Trigger condition,
+    // operator, or per-rule evaluation settings.
     expect(screen.queryByText(/Query library/)).not.toBeInTheDocument();
     expect(screen.queryByText(/Metric browser/)).not.toBeInTheDocument();
     expect(screen.queryByText('Trigger condition')).not.toBeInTheDocument();
@@ -528,5 +533,76 @@ describe('PrometheusFormSection — notification routing', () => {
     expect(screen.queryByText('Notification routing')).not.toBeInTheDocument();
     // The Labels section hint still conveys the routing relationship
     expect(screen.getByText('Categorize and route alerts')).toBeInTheDocument();
+  });
+});
+
+describe('PrometheusFormSection — Builder ⇄ Code toggle', () => {
+  // An `or`-joined expression the builder cannot represent (parseExpr → null).
+  const complexExpr = 'rate(a[5m]) > 0 or rate(b[5m]) > 0';
+
+  it('opens a builder-unrepresentable rule in Code mode showing the raw expression', () => {
+    render(
+      <PrometheusFormSection
+        form={{ ...baseForm, query: complexExpr }}
+        onUpdate={jest.fn()}
+        validationErrors={{}}
+        hasSubmitted={false}
+      />
+    );
+
+    const textarea = screen.getByTestId('prometheusPromQlExpression') as HTMLTextAreaElement;
+    expect(textarea).toBeInTheDocument();
+    expect(textarea.value).toBe(complexExpr);
+    // The builder's metric picker is not mounted in Code mode.
+    expect(screen.queryByText('Metric')).not.toBeInTheDocument();
+  });
+
+  it('opens a builder-representable rule in Builder mode (no Code textarea)', () => {
+    render(
+      <PrometheusFormSection
+        form={baseForm}
+        onUpdate={jest.fn()}
+        validationErrors={{}}
+        hasSubmitted={false}
+      />
+    );
+
+    expect(screen.queryByTestId('prometheusPromQlExpression')).not.toBeInTheDocument();
+    expect(screen.getByText('Metric')).toBeInTheDocument();
+  });
+
+  it('edits raw PromQL in Code mode without routing through the builder', () => {
+    const onUpdate = jest.fn();
+    render(
+      <PrometheusFormSection
+        form={{ ...baseForm, query: complexExpr }}
+        onUpdate={onUpdate}
+        validationErrors={{}}
+        hasSubmitted={false}
+      />
+    );
+
+    const next = `${complexExpr} or rate(c[5m]) > 0`;
+    fireEvent.change(screen.getByTestId('prometheusPromQlExpression'), { target: { value: next } });
+    expect(onUpdate).toHaveBeenCalledWith('query', next);
+  });
+
+  it('warns before the builder would overwrite an unrepresentable expression', () => {
+    render(
+      <PrometheusFormSection
+        form={{ ...baseForm, query: complexExpr }}
+        onUpdate={jest.fn()}
+        validationErrors={{}}
+        hasSubmitted={false}
+      />
+    );
+
+    // No warning in Code mode (the expression is shown as-is).
+    expect(screen.queryByTestId('prometheusBuilderOverwriteWarning')).not.toBeInTheDocument();
+
+    // Switching to Builder surfaces the overwrite guard — the raw expression is
+    // preserved until the user actually picks a metric.
+    fireEvent.click(screen.getByText('Builder'));
+    expect(screen.getByTestId('prometheusBuilderOverwriteWarning')).toBeInTheDocument();
   });
 });

--- a/public/components/alerting/create_monitor/prometheus_form_section.tsx
+++ b/public/components/alerting/create_monitor/prometheus_form_section.tsx
@@ -107,7 +107,8 @@ export const PrometheusFormSection: React.FC<{
   // A non-empty expression the builder cannot represent. Selecting a metric in
   // the builder would overwrite it, so warn (and offer Code) rather than
   // silently replacing what the user has.
-  const builderWouldOverwrite = form.query.trim() !== '' && parseExpr(form.query) === null;
+  const builderWouldOverwrite =
+    (form.query ?? '').trim() !== '' && parseExpr(form.query ?? '') === null;
 
   // Use a ref for form.labels to avoid circular dependency:
   // handleRuleGroupChange → onUpdate('labels') → parent re-renders → new form.labels → new callback

--- a/public/components/alerting/create_monitor/prometheus_form_section.tsx
+++ b/public/components/alerting/create_monitor/prometheus_form_section.tsx
@@ -9,8 +9,10 @@
  *
  * Section layout mirrors the Metrics page "Create alert rule" flyout:
  *   - Rule details (namespace, rule group, description)
- *   - Query (point-and-click builder — the PromQL expression is the
- *     complete alert condition — plus per-rule `for:` duration)
+ *   - Query — a Builder ⇄ Code toggle: the point-and-click builder OR a raw
+ *     PromQL expression (the complete alert condition), plus per-rule `for:`
+ *     duration. An existing rule the builder can't represent opens in Code so
+ *     it is never silently clobbered.
  *   - Labels
  *   - Annotations
  *   - Rule Preview (YAML)
@@ -18,7 +20,6 @@
  * Removed (not applicable to managed Prometheus):
  *   - "Unit" field / Trigger condition (the query defines the condition)
  *   - "Evaluation Settings" (managed at rule group level in AMP)
- *   - Code mode / freeform PromQL editor
  *   - Matched notification actions (routing is Alertmanager's job)
  */
 import React, { useCallback, useMemo, useRef, useState } from 'react';
@@ -27,9 +28,12 @@ import {
   EuiBadge,
   EuiBetaBadge,
   EuiButton,
+  EuiButtonGroup,
+  EuiCallOut,
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
+  EuiFormLabel,
   EuiFormRow,
   EuiLink,
   EuiPanel,
@@ -45,7 +49,11 @@ import { AnnotationEditor, LabelEditor } from '../monitor_form_components';
 import { RuleGroupSelector } from './rule_group_selector';
 import { QueryPreviewResults } from '../query_preview_results';
 import { PromQueryBuilder } from './prom_query_builder';
+import { isAlwaysFiring, parseExpr } from './prom_condition';
 import { DURATION_OPTIONS, PrometheusFormState } from './create_monitor_types';
+
+/** Which query editor the Query section shows. */
+type QueryMode = 'code' | 'builder';
 
 /** The namespace all rules created from this form are stored under. */
 const USER_RULES_NAMESPACE = 'observability-alerting';
@@ -86,6 +94,20 @@ export const PrometheusFormSection: React.FC<{
   const [showPreview, setShowPreview] = useState(false);
   // Bumped on each "Run preview" click so QueryPreviewResults re-runs the query.
   const [previewToken, setPreviewToken] = useState(0);
+
+  // Default to Builder (point-and-click), matching the Metrics-page create
+  // flyout. Exception: an existing rule whose expression the builder can't
+  // represent (any non-trivial PromQL: `or`/`and`, arithmetic, multi-comparison)
+  // opens in Code so the expression is shown as-is and never silently clobbered
+  // when the flyout mounts. Users can toggle either way.
+  const [queryMode, setQueryMode] = useState<QueryMode>(() => {
+    const seeded = (form.query ?? '').trim();
+    return seeded && parseExpr(seeded) === null ? 'code' : 'builder';
+  });
+  // A non-empty expression the builder cannot represent. Selecting a metric in
+  // the builder would overwrite it, so warn (and offer Code) rather than
+  // silently replacing what the user has.
+  const builderWouldOverwrite = form.query.trim() !== '' && parseExpr(form.query) === null;
 
   // Use a ref for form.labels to avoid circular dependency:
   // handleRuleGroupChange → onUpdate('labels') → parent re-renders → new form.labels → new callback
@@ -380,15 +402,135 @@ export const PrometheusFormSection: React.FC<{
                 )}
               />
             </EuiFlexItem>
+            <EuiFlexItem grow={false} style={{ marginLeft: 'auto' }}>
+              <EuiFormLabel>
+                {i18n.translate(
+                  'observability.alerting.prometheusFormSection.queryModeEditorLabel',
+                  {
+                    defaultMessage: 'Editor',
+                  }
+                )}
+              </EuiFormLabel>
+            </EuiFlexItem>
+            <EuiFlexItem grow={false}>
+              {/* Builder ⇄ Code toggle. Only one editor shows at a time, so an
+                expression the builder can't represent (Code) is never silently
+                overwritten by the builder's output. */}
+              <EuiButtonGroup
+                legend={i18n.translate(
+                  'observability.alerting.prometheusFormSection.queryModeLegend',
+                  { defaultMessage: 'Query editor mode' }
+                )}
+                buttonSize="compressed"
+                options={[
+                  {
+                    id: 'builder',
+                    label: i18n.translate(
+                      'observability.alerting.prometheusFormSection.queryModeBuilder',
+                      { defaultMessage: 'Builder' }
+                    ),
+                  },
+                  {
+                    id: 'code',
+                    label: i18n.translate(
+                      'observability.alerting.prometheusFormSection.queryModeCode',
+                      { defaultMessage: 'Code' }
+                    ),
+                  },
+                ]}
+                idSelected={queryMode}
+                onChange={(id) => setQueryMode(id as QueryMode)}
+                data-test-subj="prometheusQueryModeToggle"
+              />
+            </EuiFlexItem>
           </EuiFlexGroup>
 
           <EuiSpacer size="m" />
 
-          <PromQueryBuilder
-            datasourceId={datasourceId}
-            query={form.query}
-            onQueryChange={(q) => onUpdate('query', q)}
-          />
+          {queryMode === 'code' ? (
+            /* Code mode: raw PromQL expression — the complete alert condition.
+              A rule the builder can't represent lands here as-is, editable
+              directly, instead of opening a blank builder. */
+            <>
+              <EuiFormRow
+                label={i18n.translate(
+                  'observability.alerting.prometheusFormSection.expressionLabel',
+                  { defaultMessage: 'PromQL expression' }
+                )}
+                helpText={i18n.translate(
+                  'observability.alerting.prometheusFormSection.expressionHelpText',
+                  {
+                    defaultMessage:
+                      'The complete PromQL alert condition — it fires for every series the expression returns.',
+                  }
+                )}
+                fullWidth
+              >
+                <EuiTextArea
+                  value={form.query}
+                  onChange={(e) => onUpdate('query', e.target.value)}
+                  placeholder={i18n.translate(
+                    'observability.alerting.prometheusFormSection.expressionPlaceholder',
+                    { defaultMessage: 'e.g. rate(http_requests_total[5m]) > 0.5' }
+                  )}
+                  rows={2}
+                  fullWidth
+                  compressed
+                  style={{ fontFamily: 'var(--euiCodeFontFamily)' }}
+                  aria-label={i18n.translate(
+                    'observability.alerting.prometheusFormSection.expressionAriaLabel',
+                    { defaultMessage: 'PromQL expression' }
+                  )}
+                  data-test-subj="prometheusPromQlExpression"
+                />
+              </EuiFormRow>
+              {isAlwaysFiring(form.query) && (
+                <>
+                  <EuiSpacer size="s" />
+                  <EuiCallOut
+                    size="s"
+                    color="warning"
+                    iconType="alert"
+                    title={i18n.translate(
+                      'observability.alerting.prometheusFormSection.alwaysFiringWarning',
+                      {
+                        defaultMessage:
+                          'This expression has no condition, so the alert fires whenever the series exists. Add a comparison (e.g. “> 0.5”) — or a Condition in the builder — for a conditional alert.',
+                      }
+                    )}
+                    data-test-subj="prometheusAlwaysFiringWarning"
+                  />
+                </>
+              )}
+            </>
+          ) : (
+            /* Builder mode: point-and-click metric/label picker. */
+            <>
+              {builderWouldOverwrite && (
+                <>
+                  <EuiCallOut
+                    size="s"
+                    color="warning"
+                    iconType="alert"
+                    title={i18n.translate(
+                      'observability.alerting.prometheusFormSection.builderOverwriteWarning',
+                      {
+                        defaultMessage:
+                          'Your current PromQL expression can’t be represented by the builder. Selecting a metric here will replace it — switch to Code to keep editing it directly.',
+                      }
+                    )}
+                    data-test-subj="prometheusBuilderOverwriteWarning"
+                  />
+                  <EuiSpacer size="s" />
+                </>
+              )}
+              <PromQueryBuilder
+                datasourceId={datasourceId}
+                query={form.query}
+                onQueryChange={(q) => onUpdate('query', q)}
+              />
+            </>
+          )}
 
           <EuiSpacer size="m" />
 


### PR DESCRIPTION
## Summary

Fixes a **silent data-loss footgun** when editing a Prometheus rule whose expression the point-and-click builder can't represent.

The edit flyout (`PrometheusFormSection`) rendered the builder **only**. Opening a rule with any non-trivial PromQL — `or`/`and`, arithmetic, multi-comparison — showed a **blank builder** (the parser can't seed it), and the raw expression was visible only in the read-only YAML preview. Selecting any metric then **overwrote the stored expression with no warning**. e.g. editing `OtelCollectorExportFailures` and picking a metric rewrote its 3-clause `or` expression to `expr: up`.

This ports the create flyout's Builder ⇄ Code toggle + overwrite guard (`create_metrics_monitor.tsx`) into the edit flyout:
- **Defaults to Code** when the seeded expression is builder-unrepresentable (`parseExpr(query) === null`), so it opens **shown as-is** instead of blank.
- **Code mode**: a raw PromQL textarea bound to the query (plus the always-firing hint for a condition-less expression).
- **Builder mode**: warns — with a switch-to-Code affordance — before a metric pick would replace an unrepresentable expression.

The expression is now only rewritten when the user explicitly edits it.

## Visual evidence
BEFORE = `origin/main` (merge base), AFTER = this branch. Same rule (`OtelCollectorExportFailures`), viewport (1440×900), and scroll.

### Edit flyout — blank builder (no Code editor) → Code mode with the full expression
![Edit flyout before/after](https://raw.githubusercontent.com/lezzago/dashboards-observability/evidence/prom-edit-code-mode/pr-evidence/composite_edit.png)

### Flow — BEFORE: picking a metric silently wipes the expression
![before flow](https://raw.githubusercontent.com/lezzago/dashboards-observability/evidence/prom-edit-code-mode/pr-evidence/before_edit_flow.gif)

### Flow — AFTER: opens in Code with the expression; Builder is guarded
![after flow](https://raw.githubusercontent.com/lezzago/dashboards-observability/evidence/prom-edit-code-mode/pr-evidence/after_edit_flow.gif)

## Relationship to #2879
Independent and **conflict-free** — this touches only `create_monitor/prometheus_form_section.tsx` (+ its test), which #2879 does not modify. Either can merge first.

## Testing
- Plugin Jest (`jest --config ./test/jest.config.js public/components/alerting`): **50 suites / 546 tests pass**, including new `prometheus_form_sync` cases: unrepresentable rule opens in Code showing the raw expr; representable rule opens in Builder; Code edits bypass the builder; switching to Builder surfaces the overwrite guard.
- `node scripts/eslint` clean.

## Notes
- Opened as **draft** pending full CI.
