### PR TITLE
fix(alerting): tolerate text/plain wrapped empty-namespace 404 on rule create

### DIFF
--- a/server/services/slo/__tests__/ruler_client.test.ts
+++ b/server/services/slo/__tests__/ruler_client.test.ts
@@ -556,6 +556,41 @@ describe('DirectQueryRulerClient.listRuleGroups', () => {
     expect(groups).toEqual([]);
   });
 
+  // Regression (brand-new rule group / first rule create failing): the SQL
+  // plugin serves the wrapped-404 with `Content-Type: text/plain`, so the
+  // OpenSearch JS client leaves the body as an unparsed JSON *string* rather
+  // than an object. The empty-namespace classifier must parse the string
+  // envelope, not skip it — otherwise the first create in a namespace is
+  // wrongly rejected as a validation failure.
+  it('SQL plugin wrapped-404 delivered as a text/plain JSON string body → []', async () => {
+    const { client } = mockClient(() =>
+      Promise.reject(
+        rejectWithStatus(
+          400,
+          // Pretty-printed JSON string, exactly as the text/plain response
+          // reaches the transport (note the leading/inner whitespace).
+          JSON.stringify(
+            {
+              status: 400,
+              error: {
+                type: 'PrometheusClientException',
+                reason: 'Invalid Request',
+                details:
+                  'Ruler request failed with code: 404. Error details: no rule groups found\n',
+              },
+            },
+            null,
+            2
+          )
+        )
+      )
+    );
+    const svc = new DirectQueryRulerClient(noopLogger());
+
+    const groups = await svc.listRuleGroups(client, promDatasource(), 'slo-generated-ws-empty');
+    expect(groups).toEqual([]);
+  });
+
   it('HTTP 400 without the wrapped-404 marker → still throws RULER_VALIDATION_FAILED', async () => {
     const { client } = mockClient(() =>
       Promise.reject(rejectWithStatus(400, { error: { details: 'malformed namespace' } }))

--- a/server/services/slo/ruler_client.ts
+++ b/server/services/slo/ruler_client.ts
@@ -345,7 +345,13 @@ function isWrappedEmptyNamespaceError(err: unknown): boolean {
   if (extractHttpStatus(err) !== 400) return false;
   const raw = err as { body?: unknown; meta?: { body?: unknown } };
   const candidates: unknown[] = [raw?.body, raw?.meta?.body];
-  for (const candidate of candidates) {
+  for (const rawCandidate of candidates) {
+    // The SQL plugin serves this error as `text/plain`, so the OpenSearch JS
+    // client leaves the body as an unparsed JSON string rather than an object.
+    // Coerce strings back into objects before the structured checks below —
+    // otherwise the (namespace-empty) 404 is misclassified as a validation
+    // failure and the first-rule / brand-new-group create is wrongly rejected.
+    const candidate = coerceErrorEnvelope(rawCandidate);
     if (!candidate || typeof candidate !== 'object') continue;
     const error = (candidate as { error?: unknown }).error;
     if (!error || typeof error !== 'object') continue;
@@ -357,6 +363,25 @@ function isWrappedEmptyNamespaceError(err: unknown): boolean {
     if (match && match[1] === '404') return true;
   }
   return false;
+}
+
+/**
+ * Normalize a transport error body into an object for structured inspection.
+ * The SQL plugin's DirectQuery proxy returns the wrapped ruler error with
+ * `Content-Type: text/plain`, so the OpenSearch JS client does not JSON-parse
+ * it — `err.body` / `err.meta.body` arrives as a raw string. Objects pass
+ * through; strings are parsed as JSON (returning `null` on non-JSON so callers
+ * fall through to their normal error handling).
+ */
+function coerceErrorEnvelope(candidate: unknown): unknown {
+  if (typeof candidate === 'string') {
+    try {
+      return JSON.parse(candidate);
+    } catch {
+      return null;
+    }
+  }
+  return candidate;
 }
 
 function extractHttpStatus(err: unknown): number {


### PR DESCRIPTION
### Description

Creating a metrics rule with a **brand-new rule group name** is the first rule in the otherwise-empty `observability-alerting` namespace. The pre-flight `getRuleGroup` read hits the ruler's `404 'no rule groups found'`, which the SQL DirectQuery proxy wraps as an HTTP 400 `PrometheusClientException` served as `text/plain`.

Because the response is `text/plain`, the OpenSearch JS client leaves the body as an **unparsed JSON string** rather than an object. `isWrappedEmptyNamespaceError` did `typeof candidate !== 'object'` and skipped the string envelope, so the empty-namespace 404 was misclassified as `RULER_VALIDATION_FAILED` — rejecting the create before the upsert ever ran.

### Fix

Coerce string error bodies via a safe `JSON.parse` (`coerceErrorEnvelope`) before the structured `ClientException` / `code: 404` checks. Objects pass through unchanged; non-JSON strings return `null` so callers fall through to normal error handling.

Added a regression test that rejects with the real `text/plain` pretty-printed JSON **string** body and asserts `listRuleGroups` returns `[]`.

### Testing

`server/services/slo/__tests__/ruler_client.test.ts` — 30 passed (incl. new regression case).

### Check List
- [x] All tests pass
- [x] New functionality includes testing
- [x] Commit changes are listed out in CHANGELOG.md file (N/A — bug fix)
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.