### PR TITLE
fix(alerting): left-align facet filter titles and keep group count inline

### DIFF
--- a/public/components/alerting/__tests__/facet_filter_panel.test.tsx
+++ b/public/components/alerting/__tests__/facet_filter_panel.test.tsx
@@ -217,6 +217,65 @@ describe('useFacetCollapse', () => {
   });
 });
 
+describe('FacetFilterGroup — header title alignment and inline group count', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  // Regression: the facet header title used to render centered (EuiButtonEmpty
+  // defaults to text-align:center and its text span was display:block), and the
+  // group `(N)` count wrapped onto the line below the title. The fix switches
+  // the button's text span to a left-aligned flex row so the title pins
+  // flush-left and the count sits inline. jsdom does not apply stylesheets, but
+  // it preserves inline styles — which is exactly where these load-bearing
+  // props live — so we assert them directly on the DOM.
+  const getTextSpan = (toggle: HTMLElement) =>
+    toggle.querySelector<HTMLElement>('.euiButtonEmpty__text');
+
+  it('left-aligns the header title via a flex row (not a centered block span)', () => {
+    const { getByTestId } = render(<FacetFilterGroup {...defaultProps} />);
+    const textSpan = getTextSpan(getByTestId('facetGroup-status-toggle'));
+    expect(textSpan).not.toBeNull();
+    // Load-bearing for left alignment: a flex row + start alignment, NOT a
+    // display:block span that would let EuiButtonEmpty's text-align:center
+    // center the inline title.
+    expect(textSpan!.style.display).toBe('flex');
+    expect(textSpan!.style.textAlign).toBe('start');
+    expect(textSpan!.style.display).not.toBe('block');
+  });
+
+  it('lets the title <strong> flex-grow so it pins flush-left and truncates', () => {
+    const { getByTestId } = render(<FacetFilterGroup {...defaultProps} />);
+    const textSpan = getTextSpan(getByTestId('facetGroup-status-toggle'));
+    const strong = textSpan!.querySelector<HTMLElement>('strong');
+    expect(strong).not.toBeNull();
+    // `flex: 1` makes the title consume the row and left-pin the count beside it.
+    // The shorthand normalizes to `1 1 0%`, so assert the grow factor directly.
+    expect(strong!.style.flexGrow).toBe('1');
+    expect(strong!.style.minWidth).toBe('0');
+  });
+
+  it('keeps the group (N) count inline as a sibling of the title, not wrapped below', () => {
+    const { getByTestId } = render(<FacetFilterGroup {...defaultProps} showOptionCount={true} />);
+    const textSpan = getTextSpan(getByTestId('facetGroup-status-toggle'));
+    const count = getByTestId('facetGroup-status-optionCount');
+    // The count reflects the number of options and reads as `(N)`.
+    expect(count).toHaveTextContent('(3)');
+    // It must be a direct child of the flex text span (same row as the title),
+    // sitting alongside the <strong> title rather than nested inside it.
+    expect(count.parentElement).toBe(textSpan);
+    expect(textSpan!.querySelector('strong')!.contains(count)).toBe(false);
+    // The count's `flex-shrink: 0` (which keeps it a fixed-width sibling so the
+    // truncating title yields to it instead of wrapping it below) lives in the
+    // `.altFacetGroupCount` SCSS modifier. jsdom applies no stylesheets, so we
+    // assert the class is present rather than the computed flex-shrink value.
+    expect(count.className).toContain('altFacetGroupCount');
+  });
+
+  it('omits the group count when showOptionCount is false (default)', () => {
+    const { queryByTestId } = render(<FacetFilterGroup {...defaultProps} />);
+    expect(queryByTestId('facetGroup-status-optionCount')).not.toBeInTheDocument();
+  });
+});
+
 describe('FacetFilterGroup — search matches both display label and raw value', () => {
   it('filters by raw option value when displayMap provides a different label', () => {
     const props: FacetFilterGroupProps = {

--- a/public/components/alerting/facet_filter_panel.tsx
+++ b/public/components/alerting/facet_filter_panel.tsx
@@ -267,24 +267,45 @@ export const FacetFilterGroup: React.FC<FacetFilterGroupProps> = ({
             contentProps={{
               style: { justifyContent: 'flex-start', width: '100%', minWidth: 0 },
             }}
-            // The title text (plus the optional option-count suffix) has no
+            // The title (plus the optional option-count suffix) has no
             // truncation of its own, so a long facet label — or even a short
             // one once the badge + "Clear" link are showing — overflows this
             // narrow column instead of shrinking. `textProps` targets EUI's
             // internal `.euiButtonEmpty__text` span directly (there's no
             // approved-file entry for `.eui*` selectors in alerting.scss, so
             // this has to be inline style rather than CSS); `flex`/`minWidth`
-            // let it shrink inside the content span above, and the rest is a
-            // plain single-line ellipsis truncation.
+            // let it shrink inside the content span above.
+            //
+            // `display: flex` (NOT `block`) is load-bearing for two things:
+            //   1. Left alignment. EuiButtonEmpty defaults to
+            //      `text-align: center`; a `block` text span stretches full
+            //      width and centers the inline title inside it (the parent
+            //      `contentProps` justify only positions the span, not the
+            //      text within). A flex row with the `<strong>` as a
+            //      `flex: 1` child pins the title flush-left at every width.
+            //   2. Keeping the group `(N)` count (`showOptionCount`) on the
+            //      SAME line as the title. The title is wrapped in
+            //      `TruncatedLabel`, whose inner span is `display: block;
+            //      width: 100%` — inside a `block` text span that consumed the
+            //      whole line and wrapped the count underneath. A flex row lets
+            //      the truncating title (`flex: 1`) and the fixed-width count
+            //      (`flex-shrink: 0`, in `.altFacetGroupCount`) sit inline.
+            //
+            // `textAlign: 'start'` is also required, NOT just the flex row:
+            // EuiButtonEmpty's `text-align: center` is inherited into the
+            // `TruncatedLabel` inner span (`display: block; width: 100%`), so a
+            // short title (e.g. "Type", or a label key like "monitor_name"
+            // whose `<strong>` is widened by the flex row) renders its glyphs
+            // centered WITHIN that full-width span even though the span itself
+            // sits flush-left. `start` (not `left`) keeps it RTL-safe.
             textProps={{
               style: {
-                display: 'block',
+                display: 'flex',
+                alignItems: 'center',
+                textAlign: 'start',
                 flex: 1,
                 minWidth: 0,
                 maxWidth: '100%',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
               },
             }}
             iconType={isCollapsed ? 'arrowRight' : 'arrowDown'}
@@ -305,7 +326,7 @@ export const FacetFilterGroup: React.FC<FacetFilterGroupProps> = ({
                 tooltip — matching the option rows. `minWidth: 0` lets the bold
                 wrapper shrink inside the button's flex content so truncation
                 kicks in instead of overflowing. */}
-            <strong style={{ minWidth: 0, overflow: 'hidden' }}>
+            <strong style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
               <TruncatedLabel text={label} />
             </strong>
             {showOptionCount && (


### PR DESCRIPTION
## Description

The facet-header toggle button in the shared `FacetFilterGroup` rendered its title **centered** and wrapped the group `(N)` count onto the line **below** the title. Two coupled causes:

1. `EuiButtonEmpty` defaults to `text-align: center`, and the button's text span was `display: block` — so the span stretched full-width and centered the inline title inside it. (The parent `contentProps` justify only positions the span, not the text within it.)
2. `TruncatedLabel`'s inner span is `display: block; width: 100%`, so inside the block text span it consumed the whole line and pushed the `(N)` count underneath.

### Fix
Make the button's text span a **left-aligned flex row** (`display: flex`, `textAlign: 'start'`) with the title `<strong>` as a `flex: 1` child and the count as a fixed-width (`flex-shrink: 0`) sibling. `textAlign: 'start'` is required *in addition to* the flex row because `EuiButtonEmpty`'s center alignment is inherited into `TruncatedLabel`'s full-width inner span, so short titles (e.g. `Type`, `monitor_name`) would otherwise still render centered. `start` (not `left`) keeps it RTL-safe.

Affects the **Alerts**, **Monitors/Rules**, and **SLO** filter panels that share `FacetFilterGroup`.

## Visual Evidence

BEFORE = merge base (`origin/main`); AFTER = this PR. Same dev server, route, data, viewport, and theme — only the component code differs.

### 1. Facet titles: centered → flush-left

The facet titles (`Type`, `Severity`, `State`) were centered under the toggle button; they now pin flush-left, aligned with the `Filters` heading.

![Facet title alignment before/after](https://raw.githubusercontent.com/lezzago/dashboards-observability/pr2885-media/.pr-evidence/pr2885/composite_titles.png)

### Flow — BEFORE (origin/main): titles centered

Opening the Alerts filter panel and expanding each facet — titles stay centered throughout.

![Before flow](https://raw.githubusercontent.com/lezzago/dashboards-observability/pr2885-media/.pr-evidence/pr2885/before_flow.gif)

### Flow — AFTER (this PR): titles flush-left

Same interaction on this PR — titles are flush-left at every step.

![After flow](https://raw.githubusercontent.com/lezzago/dashboards-observability/pr2885-media/.pr-evidence/pr2885/after_flow.gif)

> Note: the `(N)` group-count facets (label-key facets that set `showOptionCount`) only render when there are alerts carrying labels; this dev environment has no reachable alerting backend, so those facets aren't shown above. The inline-count behavior is covered by the unit tests below.

## Issues Resolved
Facet filter titles were centered and the group count wrapped to a second line.

## Testing
Added regression tests to `facet_filter_panel.test.tsx` (jsdom preserves inline styles):
- header text span is a left-aligned flex row (`display: flex`, `textAlign: start`, not `block`)
- title `<strong>` flex-grows and can truncate
- group `(N)` count renders inline as a **sibling** of the title (not nested/wrapped below)
- count is omitted when `showOptionCount` is false (default)

All 19 tests in the suite pass; ESLint clean.

## Check List
- [x] All tests pass
- [x] New functionality includes testing
- [x] New functionality has been documented (n/a — UI-only style fix)
- [x] Commit changes are listed out in CHANGELOG.md file (n/a — UI-only style fix)
- [x] Commit changes are signed off (`Signed-off-by`)
- [x] Screenshots / visual evidence attached (before/after + flow GIFs above)
