### PR TITLE
docs: fix broken doc links after opensearch.org → docs.opensearch.org migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Additionally the fields can be sorted and filtered.
 
 ### Event Analytics
 
-Event Analytics allows user to monitor, correlate, analyze and visualize machine generated data through [Piped Processing Language](https://opensearch.org/docs/latest/observability-plugins/ppl/index/). It also enables the user to turn data-driven events into visualizations and save frequently used ones for quick access.
+Event Analytics allows user to monitor, correlate, analyze and visualize machine generated data through [Piped Processing Language](https://docs.opensearch.org/latest/search-plugins/sql/ppl/index/). It also enables the user to turn data-driven events into visualizations and save frequently used ones for quick access.
 
 ### Metrics Analytics
 
@@ -123,7 +123,7 @@ Integration usually consist of the following assets:
 
 [See Integration Tutorial](https://github.com/opensearch-project/dashboards-observability/wiki/Integration-Creation-Guide)
 
-Please See additional information [documentation](https://opensearch.org/docs/latest/integrations/index)
+Please See additional information [documentation](https://docs.opensearch.org/latest/integrations/index/)
 
 > Integration Spec [RFC](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/3412#schema-support-for-observability)
 
@@ -135,10 +135,10 @@ The Observability dashboard vision of [telemetry Data Correlation](https://githu
 
 ---
 ## WIKI Home
-Please see our WIKI page for additional information [WIKI](https://opensearch.org/docs/latest/observability/index/) to learn more about our features.
+Please see our WIKI page for additional information [WIKI](https://docs.opensearch.org/latest/observing-your-data/index/) to learn more about our features.
 
 ## Documentation
-Please see our technical [documentation](https://opensearch.org/docs/latest/observability/index/) to learn more about its features.
+Please see our technical [documentation](https://docs.opensearch.org/latest/observing-your-data/index/) to learn more about its features.
 
 ## Contributing
 - See [developer guide](DEVELOPER_GUIDE.md) and [how to contribute to this project](CONTRIBUTING.md).
@@ -148,7 +148,7 @@ Please see our technical [documentation](https://opensearch.org/docs/latest/obse
 
 If you find a bug, or have a feature request, please don't hesitate to open an issue in this repository.
 
-For more information, see [project website](https://opensearch.org/) and [documentation](https://opensearch.org/docs). If you need help and are unsure where to open an issue, try the [Forum](https://forum.opensearch.org/c/plugins/observability/49).
+For more information, see [project website](https://opensearch.org/) and [documentation](https://docs.opensearch.org/latest/). If you need help and are unsure where to open an issue, try the [Forum](https://forum.opensearch.org/c/plugins/observability/49).
 
 ## Code of Conduct
 

--- a/Using-Docker.md
+++ b/Using-Docker.md
@@ -24,7 +24,7 @@ To build the docker image use the next command:
 
 ## Run the docker compose
 The [docker-compose](docker-compose.yml) file represents a simple assembly of an OpenSearch cluster with two nodes and an opensearch dashboard that has the updated image with the latest changes in this plugin.
-> This is a test only docker compose that should not be used for production purpose - for such use cases please review this [link](https://opensearch.org/docs/latest/install-and-configure/install-opensearch/docker/)
+> This is a test only docker compose that should not be used for production purpose - for such use cases please review this [link](https://docs.opensearch.org/latest/install-and-configure/install-opensearch/docker/)
 
 ### Option 1 (All from docker)
 run `docker compose up -d` to start the services and once the service is up and running you can start testing the changes.
@@ -43,5 +43,5 @@ The dashboard service uses port `localhost:5601` for access and this was already
 
 ## Security Notice
 There is no security plugin and authentication definitions for this development test demo - pay attention not to use this configuration in a production or any environment that may contain
-confident or personal information without first changing the security definition for accessing the servers - for production use cases please review this [link](https://opensearch.org/docs/latest/install-and-configure/install-opensearch/docker/)
+confident or personal information without first changing the security definition for accessing the servers - for production use cases please review this [link](https://docs.opensearch.org/latest/install-and-configure/install-opensearch/docker/)
 

--- a/docs/integrations/setup.md
+++ b/docs/integrations/setup.md
@@ -499,6 +499,6 @@ Preparing for Publication
 
 ## Reference
 
-- Creating Dashboards in OpenSearch: https://opensearch.org/docs/latest/dashboards/dashboard/index/
+- Creating Dashboards in OpenSearch: https://docs.opensearch.org/latest/dashboards/dashboard/index/
 - Flint Assets in OpenSearch Spark: https://github.com/opensearch-project/opensearch-spark/blob/main/docs/index.md
-- Documentation of Integrations in OpenSearch Dashboards: https://opensearch.org/docs/latest/integrations/
+- Documentation of Integrations in OpenSearch Dashboards: https://docs.opensearch.org/latest/integrations/

--- a/public/components/getting_started/getting_started_artifacts/java_client/info/Getting-Started.md
+++ b/public/components/getting_started/getting_started_artifacts/java_client/info/Getting-Started.md
@@ -25,7 +25,7 @@ Add the OpenSearch Java client to your Maven project's `pom.xml` to interact wit
   <version>2.6.0</version>
 </dependency>
 ```
-See additional documentation [here](https://opensearch.org/docs/latest/clients/java/).
+See additional documentation [here](https://docs.opensearch.org/latest/clients/java/).
 
 ## Integrating OpenSearch with Your Java Project
 

--- a/public/components/getting_started/getting_started_artifacts/python_client/README.md
+++ b/public/components/getting_started/getting_started_artifacts/python_client/README.md
@@ -12,7 +12,7 @@ Install the OpenSearch Python client to interact with OpenSearch:
 ```bash
 pip install opensearch-py
 ```
-See additional documentation [here](https://opensearch.org/docs/latest/clients/python-low-level/).
+See additional documentation [here](https://docs.opensearch.org/latest/clients/python-low-level/).
 
 ## Integrating OpenSearch with Your Python Project
 

--- a/public/components/getting_started/getting_started_artifacts/python_client/info/Getting-Started.md
+++ b/public/components/getting_started/getting_started_artifacts/python_client/info/Getting-Started.md
@@ -12,7 +12,7 @@ Install the OpenSearch Python client to interact with OpenSearch:
 ```bash
 pip install opensearch-py
 ```
-See additional documentation [here](https://opensearch.org/docs/latest/clients/python-low-level/).
+See additional documentation [here](https://docs.opensearch.org/latest/clients/python-low-level/).
 
 ## Integrating OpenSearch with Your Python Project
 

--- a/server/adaptors/integrations/__data__/repository/otel-services/info/DemoLandingPage.md
+++ b/server/adaptors/integrations/__data__/repository/otel-services/info/DemoLandingPage.md
@@ -2,7 +2,7 @@
 _![](https://raw.githubusercontent.com/opensearch-project/.github/main/profile/banner.jpg)
 # OpenSearch Observability OTEL Demo
 
-Welcome to the [OpenSearch](https://opensearch.org/docs/latest) OpenTelemetry [Demo](https://opentelemetry.io/docs/demo/) documentation, which covers how to install and run the demo, and some scenarios you can use to view OpenTelemetry in action.
+Welcome to the [OpenSearch](https://docs.opensearch.org/latest/) OpenTelemetry [Demo](https://opentelemetry.io/docs/demo/) documentation, which covers how to install and run the demo, and some scenarios you can use to view OpenTelemetry in action.
 
 ## Purpose
 The purpose of this demo is to demonstrate the different capabilities of OpenSearch Observability to investigate and reflect your system.
@@ -27,7 +27,7 @@ _**The load generator**_
 ### Ingestion
 The ingestion capabilities for OpenSearch is to be able to support multiple pipelines:
 - [Data-Prepper](https://github.com/opensearch-project/data-prepper/) is an OpenSearch ingestion project that allows ingestion of OTEL standard signals using Otel-Collector
-- [Jaeger](https://opensearch.org/docs/latest/observing-your-data/trace/trace-analytics-jaeger/) is an ingestion framework which has a build in capability for pushing OTEL signals into OpenSearch
+- [Jaeger](https://docs.opensearch.org/latest/observing-your-data/trace/trace-analytics-jaeger/) is an ingestion framework which has a build in capability for pushing OTEL signals into OpenSearch
 - [Fluent-Bit](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch) is an ingestion framework which has a build in capability for pushing OTEL signals into OpenSearch
 
 ### Integrations 


### PR DESCRIPTION
## Description

The OpenSearch documentation site migrated from `opensearch.org/docs/...` to `docs.opensearch.org/...`. The old URLs now return **301/302 redirects**, and the CI **Link Checker** (lychee, configured `--accept=200,403,429`) rejects any 3xx status. As a result the `linkchecker` job now fails on **every PR** on these pre-existing links — it was green earlier today only because the old URLs still returned `200` before the migration.

This is unrelated to any feature work; it's a repo-wide docs breakage caused by an external site change.

### Fix
Updated all **14** `opensearch.org/docs` links across **7** docs/README files to their final `docs.opensearch.org` targets. Each new URL was verified to return **`200` directly** (no redirect), so lychee accepts them.

Two pages also moved path under the new site (a plain host swap would 404):
- `.../observability-plugins/ppl/index/` → `.../search-plugins/sql/ppl/index/`
- `.../observability/index/` → `.../observing-your-data/index/`

Bare `/docs` and `/docs/latest` now point at `https://docs.opensearch.org/latest/` (the trailing slash is required — the slashless form still 301s).

Files changed: `README.md`, `Using-Docker.md`, `docs/integrations/setup.md`, `server/adaptors/integrations/__data__/repository/otel-services/info/DemoLandingPage.md`, and three `getting_started_artifacts` client docs.

## Issues Resolved
Fixes the failing `linkchecker` CI job (broken `opensearch.org/docs` links).

## Testing
Verified each of the 10 unique replacement URLs returns `200` with `curl -sI` (no redirect follow), matching lychee's accept list. `grep` confirms zero remaining `opensearch.org/docs` links in checked file types.

## Check List
- [x] All tests pass
- [x] New functionality includes testing (n/a — docs-only link fix)
- [x] New functionality has been documented (n/a)
- [x] Commit changes are listed out in CHANGELOG.md file (n/a — docs-only)
- [x] Commit changes are signed off (`Signed-off-by`)