### PR TITLE
test(apm): mock serviceNodeKey in services_home test to fix broken build-linux

### DIFF
--- a/public/components/apm/pages/services_home/__tests__/services_home.test.tsx
+++ b/public/components/apm/pages/services_home/__tests__/services_home.test.tsx
@@ -25,6 +25,11 @@ const mockMetricsReturn = {
 };
 jest.mock('../../../shared/hooks/use_services_red_metrics', () => ({
   useServicesRedMetrics: () => mockMetricsReturn,
+  // `services_home.tsx` keys the metrics map with `serviceNodeKey`. Mirror the
+  // real implementation (`${serviceName}::${environment ?? ''}`) so the table
+  // cell renderers don't throw "serviceNodeKey is not a function".
+  serviceNodeKey: (serviceName: string, environment?: string) =>
+    `${serviceName}::${environment ?? ''}`,
 }));
 
 const mockTimeRange = { from: 'now-15m', to: 'now' };


### PR DESCRIPTION
## Description

`build-linux` / `build-windows-macos` are currently **red on `main` and on every open PR**: the `ServicesHome — Environment filter` suite fails all 5 tests with:

```
TypeError: (0 , _use_services_red_metrics.serviceNodeKey) is not a function
    at render (public/components/apm/pages/services_home/services_home.tsx:1094:56)
```

### Root cause
#2860 (`[APM] Harden Services, Overview, Operations, Dependencies, and Topology pages for scale`) added `serviceNodeKey` — exported from `use_services_red_metrics` and called by the services-table cell renderers in `services_home.tsx` — but did not update the jest mock in `services_home.test.tsx`, which still returns only `useServicesRedMetrics`. Every render then calls `serviceNodeKey(...)` → `undefined` → `TypeError`.

### Fix
Add `serviceNodeKey` to the mock factory, mirroring the real implementation so the metrics-map lookups resolve:

```ts
serviceNodeKey: (serviceName: string, environment?: string) => `${serviceName}::${environment ?? ''}`,
```

## Issues Resolved
Fixes the failing `build-linux` / `build-windows-macos` jest jobs (`ServicesHome — Environment filter`).

## Testing
`yarn jest services_home.test.tsx` → **5 passed, 5 total** (was 5 failed). ESLint clean.

## Check List
- [x] All tests pass
- [x] New functionality includes testing (n/a — test-mock fix)
- [x] New functionality has been documented (n/a)
- [x] Commit changes are listed out in CHANGELOG.md file (n/a — test-only)
- [x] Commit changes are signed off (`Signed-off-by`)